### PR TITLE
feat: add title-only fallback search for blocked artists

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-cov pytest-asyncio
+          pip install -e ".[dev]"
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-slskd-local-bot"
-version = "0.1.0"
+version = "0.3.3"
 description = "Automated music discovery and download via Telegram bot. Resolves metadata from Spotify, searches and downloads FLAC from Soulseek (slskd), and organizes your library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary\n\n- When full \"Artist Title\" search returns 0 results, automatically retry with just the song title\n- Bypasses Soulseek server-side artist name filters that block Prince, Linkin Park, Beatles, Michael Jackson, etc.\n- Tested: \"somewhere belong flac\" returns 250 responses vs 0 for \"linkin park somewhere i belong flac\"\n\n## Test plan\n\n- [x] 32 tests passing\n- [ ] Test with blocked artist (Prince, Linkin Park) via Telegram bot\n- [ ] Verify scoring still filters irrelevant results from broader search