### PR TITLE
feat: smart search fallback with keyword reduction + album year

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-slskd-local-bot"
-version = "0.3.4"
+version = "0.3.5"
 description = "Automated music discovery and download via Telegram bot. Resolves metadata from Spotify, searches and downloads FLAC from Soulseek (slskd), and organizes your library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from music_downloader.bot.handlers import _build_reduced_queries, _clean_search_title
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,61 @@
+"""Tests for bot handler helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from music_downloader.bot.handlers import _build_reduced_queries, _clean_search_title
+
+
+class TestBuildReducedQueries:
+    """Tests for _build_reduced_queries()."""
+
+    def test_two_word_title(self):
+        """Two-word title produces two queries, one per dropped word."""
+        result = _build_reduced_queries("Purple Rain", "1984")
+        assert result == ["Rain 1984", "Purple 1984"]
+
+    def test_three_word_title(self):
+        """Three-word title produces three queries."""
+        result = _build_reduced_queries("Somewhere I Belong", "2003")
+        assert result == [
+            "I Belong 2003",
+            "Somewhere Belong 2003",
+            "Somewhere I 2003",
+        ]
+
+    def test_single_word_title_returns_empty(self):
+        """Single-word titles are skipped (user requirement)."""
+        assert _build_reduced_queries("Crazy", "1999") == []
+
+    def test_empty_title_returns_empty(self):
+        assert _build_reduced_queries("", "2000") == []
+
+    def test_no_year_returns_empty(self):
+        """Without a year the fallback is pointless."""
+        assert _build_reduced_queries("Purple Rain", "") == []
+
+    def test_none_year_returns_empty(self):
+        assert _build_reduced_queries("Purple Rain", None) == []
+
+    def test_four_word_title(self):
+        result = _build_reduced_queries("Wish You Were Here", "1975")
+        assert len(result) == 4
+        assert result[0] == "You Were Here 1975"
+        assert result[3] == "Wish You Were 1975"
+
+
+class TestCleanSearchTitle:
+    """Tests for _clean_search_title()."""
+
+    def test_strips_remastered_suffix(self):
+        assert _clean_search_title("Purple Rain - Remastered 2009") == "Purple Rain"
+
+    def test_strips_mono_suffix(self):
+        assert _clean_search_title("Hey Jude - Mono") == "Hey Jude"
+
+    def test_strips_parenthesised_remaster(self):
+        assert _clean_search_title("Come Together (Remastered 2009)") == "Come Together"
+
+    def test_leaves_normal_title_alone(self):
+        assert _clean_search_title("Bohemian Rhapsody") == "Bohemian Rhapsody"

--- a/uv.lock
+++ b/uv.lock
@@ -743,7 +743,7 @@ wheels = [
 
 [[package]]
 name = "telegram-slskd-local-bot"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Three-tier search fallback: full query -> title only -> reduced keywords + year
- Cleans stale slskd searches before each new search (fixes empty responses API bug)
- Example: "Prince Purple Rain" fails, "Purple Rain" fails, then "Rain 1984" succeeds with 250+ results

## Test plan
- [x] 43 tests pass (11 new for handler helpers)
- [ ] Deploy and test with Prince - Purple Rain via Telegram bot