### PR TITLE
feat: add FLAC authenticity analysis via spectral cutoff detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
+# Install system dependencies (libsndfile1 needed for FLAC spectral analysis)
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends libsndfile1 && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy requirements first for better caching
 COPY requirements.txt .
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-02-09
+
+### Added
+
+- FLAC authenticity analysis via spectral cutoff detection on downloaded files
+  - Verdicts: AUTHENTIC, WARNING, SUSPICIOUS, FAKE shown before save approval
+  - Uses Welch's PSD method to detect lossy-to-lossless transcodes
+- Fallback to `send_document` when `send_audio` fails (BadRequest edge cases)
+- New dependencies: numpy, scipy, soundfile for spectral analysis
+- 9 new tests for FLAC analyzer (synthetic audio generation with controlled cutoffs)
+
+### Changed
+
+- Large file message improved with quality info and analysis results
+- Download preview now shows FLAC authenticity verdict alongside quality info
+- Dockerfile: added libsndfile1 system dependency for soundfile
+
+## [0.3.5] - 2026-02-08
+
+### Added
+
+- Three-tier search fallback: full query -> title-only -> keyword reduction + album year
+- Stale search cleanup before each new search (fixes slskd API caching bug)
+- Configurable MAX_RESULTS environment variable for FLAC result display count
+
+### Changed
+
+- Default FLAC results display increased from 5 to 10
+
 ## [0.1.0] - 2026-02-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-slskd-local-bot"
-version = "0.3.5"
+version = "0.4.0"
 description = "Automated music discovery and download via Telegram bot. Resolves metadata from Spotify, searches and downloads FLAC from Soulseek (slskd), and organizes your library."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -33,6 +33,9 @@ dependencies = [
     "uvicorn>=0.32.0",
     "python-dotenv>=1.0.1",
     "httpx>=0.28.0",
+    "numpy>=1.26.0",
+    "scipy>=1.12.0",
+    "soundfile>=0.12.1",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ fastapi>=0.115.0
 uvicorn>=0.32.0
 python-dotenv>=1.0.1
 httpx>=0.28.0
+numpy>=1.26.0
+scipy>=1.12.0
+soundfile>=0.12.1

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -711,9 +711,7 @@ class MusicBot:
 
             # Update status message
             await status_msg.edit_text(
-                f"✅ *{label} Downloaded!* Sending preview...\n"
-                f"`{result.basename}`\n"
-                f"{quality_line}",
+                f"✅ *{label} Downloaded!* Sending preview...\n`{result.basename}`\n{quality_line}",
                 parse_mode=ParseMode.MARKDOWN,
             )
 

--- a/src/music_downloader/processor/flac_analyzer.py
+++ b/src/music_downloader/processor/flac_analyzer.py
@@ -38,10 +38,10 @@ class FlacVerdict:
     @property
     def emoji(self) -> str:
         return {
-            "AUTHENTIC": "\u2705",   # ✅
+            "AUTHENTIC": "\u2705",  # ✅
             "WARNING": "\u26a0\ufe0f",  # ⚠️
             "SUSPICIOUS": "\U0001f7e0",  # 🟠
-            "FAKE": "\u274c",        # ❌
+            "FAKE": "\u274c",  # ❌
         }.get(self.verdict, "\u2753")  # ❓
 
     @property

--- a/src/music_downloader/processor/flac_analyzer.py
+++ b/src/music_downloader/processor/flac_analyzer.py
@@ -1,0 +1,170 @@
+"""
+FLAC authenticity analyzer via spectral analysis.
+
+Detects fake FLAC files (transcoded from lossy sources) by examining
+the high-frequency content.  True lossless audio has energy up to the
+Nyquist frequency (~22.05 kHz at 44.1 kHz sample rate).  Lossy-to-lossless
+transcodes show a sharp spectral energy cutoff between 16-20 kHz caused by
+the original encoder's low-pass filter.
+
+Verdicts:
+    AUTHENTIC  - spectrum extends to Nyquist, no cutoff detected
+    WARNING    - cutoff 19-20 kHz (might be high-quality MP3 320kbps or older recording)
+    SUSPICIOUS - cutoff 17-19 kHz (likely MP3 192-256kbps source)
+    FAKE       - cutoff <17 kHz (definitely transcoded from lossy)
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+
+import numpy as np
+import soundfile as sf
+from scipy import signal
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FlacVerdict:
+    """Result of FLAC authenticity analysis."""
+
+    verdict: str  # AUTHENTIC, WARNING, SUSPICIOUS, FAKE
+    cutoff_khz: float
+    nyquist_khz: float
+    sample_rate: int
+    bit_depth: int
+
+    @property
+    def emoji(self) -> str:
+        return {
+            "AUTHENTIC": "\u2705",   # ✅
+            "WARNING": "\u26a0\ufe0f",  # ⚠️
+            "SUSPICIOUS": "\U0001f7e0",  # 🟠
+            "FAKE": "\u274c",        # ❌
+        }.get(self.verdict, "\u2753")  # ❓
+
+    @property
+    def display(self) -> str:
+        """One-line human-readable summary for Telegram."""
+        if self.verdict == "AUTHENTIC":
+            return f"{self.emoji} Lossless OK (spectrum to {self.cutoff_khz:.1f}kHz)"
+        label = {
+            "WARNING": "Possible transcode",
+            "SUSPICIOUS": "Likely transcode",
+            "FAKE": "Fake lossless",
+        }.get(self.verdict, self.verdict)
+        return f"{self.emoji} {label} (cutoff {self.cutoff_khz:.1f}kHz)"
+
+
+def analyze_flac(filepath: str, sample_duration: float = 30.0) -> FlacVerdict | None:
+    """
+    Analyze a FLAC file for losslessness via spectral cutoff detection.
+
+    Reads a 30-second segment from the middle of the file, computes the
+    power spectral density, and looks for a sharp energy drop above 14 kHz.
+
+    Args:
+        filepath: Path to a FLAC file on disk.
+        sample_duration: Seconds of audio to analyze (from the middle).
+
+    Returns:
+        FlacVerdict with the analysis result, or None on error.
+    """
+    try:
+        info = sf.info(filepath)
+        sr = info.samplerate
+        nyquist = sr / 2
+
+        # Parse bit depth from subtype (e.g. "PCM_16" -> 16, "PCM_24" -> 24)
+        bit_match = re.search(r"\d+", info.subtype or "")
+        bit_depth = int(bit_match.group()) if bit_match else 0
+
+        # Read a segment from the middle of the file (avoids silence at start/end)
+        total_frames = info.frames
+        start_frame = max(0, total_frames // 3)
+        frames_to_read = min(int(sr * sample_duration), total_frames - start_frame)
+
+        data, _ = sf.read(filepath, start=start_frame, frames=frames_to_read, dtype="float32")
+
+        # If stereo, average channels
+        if data.ndim > 1:
+            data = data.mean(axis=1)
+
+        # Skip near-silent files
+        rms = np.sqrt(np.mean(data**2))
+        if rms < 0.001:
+            return FlacVerdict(
+                verdict="AUTHENTIC",
+                cutoff_khz=nyquist / 1000,
+                nyquist_khz=nyquist / 1000,
+                sample_rate=sr,
+                bit_depth=bit_depth,
+            )
+
+        # Compute power spectral density using Welch's method
+        nperseg = min(8192, len(data))
+        freqs, psd = signal.welch(data, fs=sr, nperseg=nperseg, noverlap=nperseg // 2)
+
+        # Convert to dB
+        psd_db = 10 * np.log10(psd + 1e-30)
+
+        # Analyze high-frequency region (above 14 kHz)
+        high_freq_mask = freqs >= 14000
+        high_freqs = freqs[high_freq_mask]
+        high_psd = psd_db[high_freq_mask]
+
+        if len(high_freqs) < 10:
+            return FlacVerdict(
+                verdict="AUTHENTIC",
+                cutoff_khz=nyquist / 1000,
+                nyquist_khz=nyquist / 1000,
+                sample_rate=sr,
+                bit_depth=bit_depth,
+            )
+
+        # Reference level: average energy in the mid-frequency band (2-8 kHz)
+        mid_mask = (freqs >= 2000) & (freqs <= 8000)
+        mid_energy = np.mean(psd_db[mid_mask]) if np.any(mid_mask) else -60
+
+        # Find where high-frequency energy drops more than 30dB below mid-band
+        threshold = mid_energy - 30
+        cutoff_idx = np.where(high_psd < threshold)[0]
+
+        cutoff_freq = float(nyquist)
+        if len(cutoff_idx) > 0:
+            # Find the first sustained drop (at least 3 consecutive bins below threshold)
+            consecutive = 0
+            for i in range(len(cutoff_idx) - 1):
+                if cutoff_idx[i + 1] - cutoff_idx[i] == 1:
+                    consecutive += 1
+                    if consecutive >= 3:
+                        cutoff_freq = float(high_freqs[cutoff_idx[i - 2]])
+                        break
+                else:
+                    consecutive = 0
+
+        cutoff_khz = cutoff_freq / 1000
+        nyquist_khz = nyquist / 1000
+
+        # Determine verdict based on cutoff frequency
+        if cutoff_khz >= nyquist_khz * 0.92:  # within ~8% of Nyquist
+            verdict = "AUTHENTIC"
+        elif cutoff_khz >= 19.0:
+            verdict = "WARNING"
+        elif cutoff_khz >= 17.0:
+            verdict = "SUSPICIOUS"
+        else:
+            verdict = "FAKE"
+
+        return FlacVerdict(
+            verdict=verdict,
+            cutoff_khz=round(cutoff_khz, 2),
+            nyquist_khz=round(nyquist_khz, 2),
+            sample_rate=sr,
+            bit_depth=bit_depth,
+        )
+
+    except Exception:
+        logger.exception("Failed to analyze FLAC: %s", filepath)
+        return None

--- a/tests/test_flac_analyzer.py
+++ b/tests/test_flac_analyzer.py
@@ -1,0 +1,128 @@
+"""Tests for FLAC authenticity analyzer."""
+
+import os
+import tempfile
+
+import numpy as np
+import soundfile as sf
+
+from music_downloader.processor.flac_analyzer import FlacVerdict, analyze_flac
+
+
+class TestFlacVerdict:
+    """Test FlacVerdict display properties."""
+
+    def test_authentic_display(self):
+        v = FlacVerdict(verdict="AUTHENTIC", cutoff_khz=22.05, nyquist_khz=22.05, sample_rate=44100, bit_depth=16)
+        assert "Lossless OK" in v.display
+        assert "22.1kHz" in v.display
+        assert v.emoji == "\u2705"
+
+    def test_warning_display(self):
+        v = FlacVerdict(verdict="WARNING", cutoff_khz=19.5, nyquist_khz=22.05, sample_rate=44100, bit_depth=16)
+        assert "Possible transcode" in v.display
+        assert "19.5kHz" in v.display
+        assert v.emoji == "\u26a0\ufe0f"
+
+    def test_suspicious_display(self):
+        v = FlacVerdict(verdict="SUSPICIOUS", cutoff_khz=18.0, nyquist_khz=22.05, sample_rate=44100, bit_depth=16)
+        assert "Likely transcode" in v.display
+        assert "18.0kHz" in v.display
+
+    def test_fake_display(self):
+        v = FlacVerdict(verdict="FAKE", cutoff_khz=16.0, nyquist_khz=22.05, sample_rate=44100, bit_depth=16)
+        assert "Fake lossless" in v.display
+        assert "16.0kHz" in v.display
+        assert v.emoji == "\u274c"
+
+
+class TestAnalyzeFlac:
+    """Test analyze_flac with synthetic FLAC files."""
+
+    @staticmethod
+    def _create_test_flac(
+        filepath: str,
+        sample_rate: int = 44100,
+        duration: float = 5.0,
+        cutoff_hz: float | None = None,
+    ):
+        """Create a synthetic FLAC file.
+
+        If cutoff_hz is None, generate broadband white noise (authentic).
+        If cutoff_hz is set, low-pass filter the noise to simulate a transcode.
+        """
+        from scipy.signal import butter, sosfilt
+
+        n_samples = int(sample_rate * duration)
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal(n_samples).astype(np.float32)
+
+        if cutoff_hz is not None:
+            nyquist = sample_rate / 2
+            # Butterworth low-pass to create a sharp spectral cutoff
+            sos = butter(10, cutoff_hz / nyquist, btype="low", output="sos")
+            data = sosfilt(sos, data).astype(np.float32)
+
+        # Normalize
+        data = data / np.max(np.abs(data)) * 0.8
+
+        sf.write(filepath, data, sample_rate, subtype="PCM_16")
+
+    def test_authentic_flac(self):
+        """Broadband white noise FLAC should be AUTHENTIC."""
+        with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as f:
+            path = f.name
+        try:
+            self._create_test_flac(path)  # no cutoff = broadband
+            result = analyze_flac(path, sample_duration=5.0)
+            assert result is not None
+            assert result.verdict == "AUTHENTIC"
+            assert result.sample_rate == 44100
+            assert result.bit_depth == 16
+        finally:
+            os.unlink(path)
+
+    def test_fake_flac_low_cutoff(self):
+        """FLAC with sharp low-pass at 15kHz should be detected as FAKE."""
+        with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as f:
+            path = f.name
+        try:
+            self._create_test_flac(path, cutoff_hz=15000.0)
+            result = analyze_flac(path, sample_duration=5.0)
+            assert result is not None
+            assert result.verdict in ("FAKE", "SUSPICIOUS")
+        finally:
+            os.unlink(path)
+
+    def test_silent_file_is_authentic(self):
+        """A near-silent file should default to AUTHENTIC (can't analyze)."""
+        with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as f:
+            path = f.name
+        try:
+            n_samples = 44100 * 3
+            data = np.zeros(n_samples, dtype=np.float32)
+            sf.write(path, data, 44100, subtype="PCM_16")
+            result = analyze_flac(path, sample_duration=3.0)
+            assert result is not None
+            assert result.verdict == "AUTHENTIC"
+        finally:
+            os.unlink(path)
+
+    def test_nonexistent_file_returns_none(self):
+        """Analyzing a non-existent file should return None."""
+        result = analyze_flac("/tmp/nonexistent_test_file.flac")
+        assert result is None
+
+    def test_hi_res_authentic(self):
+        """96kHz broadband file should be AUTHENTIC with 48kHz Nyquist."""
+        with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as f:
+            path = f.name
+        try:
+            self._create_test_flac(path, sample_rate=96000)
+            result = analyze_flac(path, sample_duration=5.0)
+            assert result is not None
+            assert result.verdict == "AUTHENTIC"
+            assert result.sample_rate == 96000
+            assert result.nyquist_khz == 48.0
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
## Summary

- Adds FLAC authenticity analysis using spectral cutoff detection (Welch's PSD method) on every downloaded FLAC file
- Verdicts (AUTHENTIC ✅, WARNING ⚠️, SUSPICIOUS 🟠, FAKE ❌) shown inline in download preview before user approves saving
- Adds `send_document` fallback when `send_audio` fails (BadRequest edge cases)
- Improves large file (>50MB) message with quality info and analysis results
- New deps: numpy, scipy, soundfile + libsndfile1 in Docker image

## Test plan

- [x] 52 tests pass (9 new for FLAC analyzer with synthetic audio files)
- [x] Ruff lint clean
- [ ] Build Docker image and test with real FLAC downloads on watchtower
- [ ] Verify spectral analysis runs fast enough (<5s per file) in-line with download flow