### PR TITLE
feat: paginated browsing for Spotify and slskd results

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-slskd-local-bot"
-version = "0.4.0"
+version = "0.5.0"
 description = "Automated music discovery and download via Telegram bot. Resolves metadata from Spotify, searches and downloads FLAC from Soulseek (slskd), and organizes your library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Add ◀️ Prev / Next ▶️ navigation buttons to both Spotify match selection and slskd search results
- Spotify now fetches 20 candidates (up from 10) and displays 5 per page with page indicators
- slskd results display `max_results` per page with full forward/back navigation
- Absolute indices in callback data ensure selections work correctly from any page

## Test plan

- [x] All 56 existing tests pass
- [ ] Search for an ambiguous query (e.g. `prince christ stauros`) and verify Spotify shows ◀️/▶️ buttons when more than 5 results exist
- [ ] Navigate Spotify pages and select a track from page 2+
- [ ] Verify slskd results show pagination when more than 10 matches found
- [ ] Navigate slskd pages and download from page 2+
- [ ] Verify "Auto-pick best" and "Cancel" buttons still work on all pages