### PR TITLE
feat: bold filenames in search results for readability

### DIFF
--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -949,7 +949,7 @@ class MusicBot:
         for i in range(start, end):
             t = tracks[i]
             lines.append(
-                f"*#{i + 1}* {t.artist} - {t.title}\n"
+                f"*#{i + 1} {t.artist} - {t.title}*\n"
                 f"    Album: {t.album} ({t.year}) | {t.duration_display}\n"
                 f"    [Listen on Spotify]({t.spotify_url})"
             )
@@ -996,7 +996,7 @@ class MusicBot:
             lines.append(
                 f"*#{i + 1}* {slot_icon} `{r.duration_display}` | "
                 f"{r.quality_display}{format_tag} | {r.size_mb:.0f}MB\n"
-                f"    {safe_name}"
+                f"    *{safe_name}*"
             )
 
         return "\n".join(lines)


### PR DESCRIPTION
## Summary

- Make filenames **bold** in slskd results display for easier reading
- Make artist-title **bold** in Spotify match listings

## Test plan

- [x] All 56 tests pass
- [ ] Verify filenames appear bold in Telegram slskd results
- [ ] Verify artist-title appears bold in Spotify match list