### PR TITLE
feat: cancel-on-message, OGG conversion, dismiss-on-approve

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ffmpeg
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM python:3.11-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies (libsndfile1 needed for FLAC spectral analysis)
+# Install system dependencies
+# libsndfile1: FLAC spectral analysis (soundfile)
+# ffmpeg: audio trimming/conversion for Telegram previews
 RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends libsndfile1 && \
+    apt-get install -y --no-install-recommends libsndfile1 ffmpeg && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-02-23
+
+### Added
+
+- Cancel-on-new-message: sending a new query while mid-search or mid-download
+  cancels all in-flight operations for that chat instantly (generation counter
+  + asyncio task cancellation)
+- Large file OGG conversion: files >50 MB are converted to OGG Opus and sent
+  in full; only trimmed to ~1 min if the OGG still exceeds 50 MB
+- `convert_to_ogg()` utility (ffmpeg-based, handles any audio format)
+- ffmpeg added as Docker system dependency for reliable audio conversion
+- Dismiss-on-approve: saving one download to library automatically cancels all
+  other pending downloads for the same chat (buttons removed, messages updated)
+- `approval_message_id` tracking on `PendingDownload` for programmatic message edits
+
+### Changed
+
+- Results keyboard is now locked after selecting a download (no duplicate picks)
+- Preview clips use ffmpeg → OGG Opus instead of soundfile (handles all formats)
+- Default preview trim duration changed from 30 s to 60 s
+- Stale approve/reject buttons now show "⏹ Cancelled" instead of silently
+  disappearing
+
+### Fixed
+
+- "File too large for Telegram" text-only fallback no longer appears; files are
+  always sent as playable audio (OGG conversion or trimmed clip)
+
 ## [0.4.0] - 2026-02-09
 
 ### Added

--- a/src/music_downloader/__init__.py
+++ b/src/music_downloader/__init__.py
@@ -1,3 +1,3 @@
 """telegram-slskd-local-bot - Automated music discovery and download via Telegram bot."""
 
-__version__ = "0.6.4"
+__version__ = "0.7.0"

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -2,6 +2,7 @@
 Telegram bot handlers for music search and download.
 """
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -28,12 +29,17 @@ from music_downloader.bot.keyboards import (
     build_spotify_keyboard,
 )
 from music_downloader.config import Config
-from music_downloader.tools.embed_artwork import embed_artwork_into_file, fetch_spotify_artwork
 from music_downloader.metadata.spotify import SpotifyResolver, TrackInfo
 from music_downloader.processor.file_handler import FileProcessor
-from music_downloader.processor.flac_analyzer import FlacVerdict, analyze_flac, create_preview_clip
+from music_downloader.processor.flac_analyzer import (
+    FlacVerdict,
+    analyze_flac,
+    convert_to_ogg,
+    create_preview_clip,
+)
 from music_downloader.search.scorer import ResultScorer
 from music_downloader.search.slskd_client import SearchResult, SlskdClient
+from music_downloader.tools.embed_artwork import embed_artwork_into_file, fetch_spotify_artwork
 
 logger = logging.getLogger(__name__)
 
@@ -133,13 +139,44 @@ def _has_non_latin_script(text: str) -> bool:
     return any(c.isalpha() and ord(c) > 0x024F for c in text)
 
 
-_NOISE_WORDS = frozenset({
-    "single", "version", "long", "short", "full", "edit", "mix",
-    "remastered", "remaster", "deluxe", "edition", "bonus", "track",
-    "album", "mono", "stereo", "original", "extended",
-    "feat", "featuring", "ft", "the", "an", "and", "or", "of",
-    "in", "on", "at", "to", "for", "with", "from", "by",
-})
+_NOISE_WORDS = frozenset(
+    {
+        "single",
+        "version",
+        "long",
+        "short",
+        "full",
+        "edit",
+        "mix",
+        "remastered",
+        "remaster",
+        "deluxe",
+        "edition",
+        "bonus",
+        "track",
+        "album",
+        "mono",
+        "stereo",
+        "original",
+        "extended",
+        "feat",
+        "featuring",
+        "ft",
+        "the",
+        "an",
+        "and",
+        "or",
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "with",
+        "from",
+        "by",
+    }
+)
 
 
 def _extract_latin_keywords(title: str) -> list[str]:
@@ -170,8 +207,10 @@ class PendingDownload:
 
     track: TrackInfo
     result: SearchResult
+    chat_id: int
     source_path: str | None = None  # Path in /downloads
     status_message_id: int | None = None
+    approval_message_id: int | None = None  # Message with approve/reject buttons
 
 
 class MusicBot:
@@ -208,6 +247,13 @@ class MusicBot:
         # Download history (last N downloads)
         self.history: list[dict] = []
 
+        # Per-chat cancellation: generation counter bumped on each new text message.
+        # Running search/download flows check their generation against the current
+        # value and abort silently when superseded by a newer request.
+        self._chat_generation: dict[int, int] = {}
+        # Background tasks (downloads) tracked per chat for cancellation.
+        self._active_tasks: dict[int, set[asyncio.Task]] = {}
+
     def _is_authorized(self, user_id: int) -> bool:
         """Check if a user is authorized to use the bot."""
         if not self.config.telegram_allowed_users:
@@ -220,6 +266,46 @@ class MusicBot:
             await update.message.reply_text("You are not authorized to use this bot.")
             return False
         return True
+
+    # =========================================================================
+    # CANCELLATION
+    # =========================================================================
+
+    def _cancel_chat_operations(self, chat_id: int) -> bool:
+        """Cancel all active operations for a chat.
+
+        Bumps the generation counter (signals running search flows to abort)
+        and cancels tracked background tasks (downloads).
+
+        Returns True if something was actually cancelled.
+        """
+        had_work = bool(
+            self.pending.get(chat_id) or self._spotify_candidates.get(chat_id) or self._active_tasks.get(chat_id)
+        )
+
+        self._chat_generation[chat_id] = self._chat_generation.get(chat_id, 0) + 1
+
+        for task in self._active_tasks.pop(chat_id, set()):
+            task.cancel()
+
+        self.pending.pop(chat_id, None)
+        self._spotify_candidates.pop(chat_id, None)
+        self._spotify_page.pop(chat_id, None)
+
+        stale_ids = [k for k, v in self.downloads.items() if v.chat_id == chat_id]
+        for dl_id in stale_ids:
+            del self.downloads[dl_id]
+
+        return had_work
+
+    def _is_stale(self, chat_id: int, generation: int) -> bool:
+        """True when *generation* has been superseded by a newer request."""
+        return self._chat_generation.get(chat_id, 0) != generation
+
+    def _track_task(self, chat_id: int, task: asyncio.Task):
+        """Register a background task for cancellation tracking."""
+        self._active_tasks.setdefault(chat_id, set()).add(task)
+        task.add_done_callback(lambda t: self._active_tasks.get(chat_id, set()).discard(t))
 
     # =========================================================================
     # COMMAND HANDLERS
@@ -315,6 +401,10 @@ class MusicBot:
 
         chat_id = update.effective_chat.id
 
+        # Cancel any in-flight search / download for this chat immediately.
+        self._cancel_chat_operations(chat_id)
+        generation = self._chat_generation[chat_id]
+
         # Step 0: Check for similar files already in the library
         similar = self.processor.find_similar(query)
         if similar:
@@ -324,13 +414,12 @@ class MusicBot:
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=build_duplicate_keyboard(),
             )
-            # Store the query so we can resume if user clicks "Continue"
             self.pending[chat_id] = PendingSearch(query=query, track=None)
             return
 
-        await self._do_search(update, context, query)
+        await self._do_search(update, context, query, generation)
 
-    async def _do_search(self, update: Update, context: ContextTypes.DEFAULT_TYPE, query: str):
+    async def _do_search(self, update: Update, context: ContextTypes.DEFAULT_TYPE, query: str, generation: int):
         """Resolve metadata via Spotify, then proceed to slskd search."""
         chat_id = update.effective_chat.id
 
@@ -341,8 +430,10 @@ class MusicBot:
         )
 
         try:
-            # Get multiple Spotify results (fetch many, paginate in UI)
             tracks = self.spotify.search_multiple(query, limit=20)
+            if self._is_stale(chat_id, generation):
+                return
+
             if not tracks:
                 await _safe_edit(
                     searching_msg,
@@ -351,18 +442,13 @@ class MusicBot:
                 )
                 return
 
-            # If the query has "artist - title" form, use the artist portion
-            # to filter out irrelevant Spotify results (Spotify search is loose).
             query_artist = ""
             if " - " in query:
                 query_artist = query.split(" - ", 1)[0].strip().lower()
 
-            # Deduplicate by artist + title + album (preserves remastered,
-            # live, deluxe editions while collapsing true duplicates).
             seen = set()
             unique_tracks = []
             for t in tracks:
-                # Skip results whose artist doesn't match the queried one
                 if query_artist and query_artist not in t.artist.lower():
                     continue
                 key = (t.artist.lower(), t.title.lower(), t.album.lower())
@@ -370,7 +456,6 @@ class MusicBot:
                     seen.add(key)
                     unique_tracks.append(t)
 
-            # If artist filter removed everything, fall back to unfiltered dedup
             if not unique_tracks:
                 seen = set()
                 for t in tracks:
@@ -379,12 +464,10 @@ class MusicBot:
                         seen.add(key)
                         unique_tracks.append(t)
 
-            # If only 1 unique track, auto-select and go straight to slskd
             if len(unique_tracks) == 1:
-                await self._do_slskd_search(context, chat_id, unique_tracks[0], searching_msg)
+                await self._do_slskd_search(context, chat_id, unique_tracks[0], searching_msg, generation)
                 return
 
-            # Multiple distinct tracks — store them and let user pick (page 0)
             self._spotify_candidates[chat_id] = unique_tracks
             self._spotify_page[chat_id] = 0
             await _safe_edit(
@@ -401,7 +484,7 @@ class MusicBot:
             self._spotify_page.pop(chat_id, None)
             await _safe_edit(searching_msg, "Something went wrong. Please try again.")
 
-    async def _do_slskd_search(self, context, chat_id: int, track: TrackInfo, searching_msg):
+    async def _do_slskd_search(self, context, chat_id: int, track: TrackInfo, searching_msg, generation: int):
         """Search slskd for a resolved Spotify track."""
         try:
             await _safe_edit(
@@ -413,29 +496,25 @@ class MusicBot:
                 parse_mode=ParseMode.MARKDOWN,
             )
 
-            # Single search — filter by format locally instead of adding
-            # "flac" to the query (Soulseek keyword matching is unreliable
-            # for extensions embedded in file paths).
-            # Also strip Spotify version suffixes like "- Remastered 2009",
-            # "- Mono" etc. that add useless keywords and kill results.
             clean_title = _clean_search_title(track.title)
             search_query = f"{track.artist} {clean_title}"
             raw_responses = await self.slskd.search(search_query, timeout_secs=self.config.search_timeout_secs)
+            if self._is_stale(chat_id, generation):
+                return
 
-            # Try FLAC first from the same result set
             flac_results = self.slskd.parse_results(raw_responses, flac_only=True)
             ranked = self.scorer.score_results(flac_results, track)
             is_fallback = False
 
-            # Fallback: no FLAC survived scoring — try all audio formats
             if not ranked:
                 all_audio = self.slskd.parse_results(raw_responses, flac_only=False)
                 ranked = self.scorer.score_results(all_audio, track)
                 is_fallback = bool(ranked)
 
-            # Fallback 2: try song-name-only search (bypasses server-side
-            # artist-name filters that block e.g. Prince, Linkin Park, Beatles).
+            # Fallback 2: title-only search
             if not ranked:
+                if self._is_stale(chat_id, generation):
+                    return
                 logger.info(
                     "No results for '%s', retrying with title-only: '%s'",
                     search_query,
@@ -448,6 +527,8 @@ class MusicBot:
                     parse_mode=ParseMode.MARKDOWN,
                 )
                 raw_responses = await self.slskd.search(clean_title, timeout_secs=self.config.search_timeout_secs)
+                if self._is_stale(chat_id, generation):
+                    return
 
                 flac_results = self.slskd.parse_results(raw_responses, flac_only=True)
                 ranked = self.scorer.score_results(flac_results, track)
@@ -456,16 +537,12 @@ class MusicBot:
                     ranked = self.scorer.score_results(all_audio, track)
                     is_fallback = bool(ranked)
 
-            # Fallback 3: keyword reduction + album year.
-            # Some phrases are blocked entirely (e.g. "Purple Rain").
-            # Dropping one word at a time and appending the year often
-            # bypasses filters while keeping results relevant.
-            # Skip when the title contains non-Latin scripts (CJK, Cyrillic,
-            # etc.) — every permutation still carries those characters and
-            # will return 0 results, wasting minutes of search time.
+            # Fallback 3: keyword reduction + album year
             if not ranked and not _has_non_latin_script(clean_title):
                 reduced_queries = _build_reduced_queries(clean_title, track.year)
                 if reduced_queries:
+                    if self._is_stale(chat_id, generation):
+                        return
                     logger.info(
                         "No results for title-only '%s', trying keyword reduction + year",
                         clean_title,
@@ -477,6 +554,8 @@ class MusicBot:
                         parse_mode=ParseMode.MARKDOWN,
                     )
                     for fallback_query in reduced_queries:
+                        if self._is_stale(chat_id, generation):
+                            return
                         raw_responses = await self.slskd.search(
                             fallback_query, timeout_secs=self.config.search_timeout_secs
                         )
@@ -492,16 +571,10 @@ class MusicBot:
                             logger.info("Keyword-reduction fallback hit (non-FLAC): '%s'", fallback_query)
                             break
 
-            # Fallback 4: artist + meaningful Latin keywords from the title.
-            # When titles contain non-Latin characters, Soulseek's
-            # all-keywords-must-match logic kills every query that
-            # carries those characters.  We extract only meaningful
-            # Latin keywords (e.g. "KURENAI" from "紅 - KURENAI - シングル…")
-            # and search for "{artist} {keywords}".  Duration tolerance is
-            # relaxed because the exact Spotify version (single/live/remaster)
-            # may not exist on Soulseek — a different version of the correct
-            # song is far better than "no results".
+            # Fallback 4: artist + Latin keywords
             if not ranked:
+                if self._is_stale(chat_id, generation):
+                    return
                 latin_kw = _extract_latin_keywords(clean_title)
                 if latin_kw:
                     fb4_query = f"{track.artist} {' '.join(latin_kw)}"
@@ -513,8 +586,7 @@ class MusicBot:
                 )
                 await _safe_edit(
                     searching_msg,
-                    f"🎵 *{track.artist} - {track.title}*\n\n"
-                    f"Still no results — trying artist + keyword search…",
+                    f"🎵 *{track.artist} - {track.title}*\n\nStill no results — trying artist + keyword search…",
                     parse_mode=ParseMode.MARKDOWN,
                 )
                 raw_responses = await self.slskd.search(
@@ -522,11 +594,15 @@ class MusicBot:
                     timeout_secs=self.config.search_timeout_secs,
                     response_limit=150,
                 )
+                if self._is_stale(chat_id, generation):
+                    return
 
                 for flac_only in (True, False):
                     parsed = self.slskd.parse_results(raw_responses, flac_only=flac_only)
                     ranked = self.scorer.score_results(
-                        parsed, track, max_duration_diff=120,
+                        parsed,
+                        track,
+                        max_duration_diff=120,
                     )
                     if ranked:
                         if not flac_only:
@@ -538,6 +614,9 @@ class MusicBot:
                         )
                         break
 
+            if self._is_stale(chat_id, generation):
+                return
+
             if not ranked:
                 await _safe_edit(
                     searching_msg,
@@ -548,7 +627,6 @@ class MusicBot:
                 )
                 return
 
-            # Store pending search
             self.pending[chat_id] = PendingSearch(
                 query=f"{track.artist} {track.title}",
                 track=track,
@@ -557,7 +635,6 @@ class MusicBot:
                 is_fallback=is_fallback,
             )
 
-            # Show results with selection keyboard (page 0)
             results_text = self._format_results(track, ranked, is_fallback, page=0, page_size=self.config.max_results)
             await _safe_edit(
                 searching_msg,
@@ -640,12 +717,12 @@ class MusicBot:
             await query.edit_message_text("Cancelled.")
             return
 
-        # User chose to continue — proceed with the search
         await query.edit_message_text(
             f"Continuing with search: `{pending.query}`",
             parse_mode=ParseMode.MARKDOWN,
         )
-        await self._do_search(update, context, pending.query)
+        generation = self._chat_generation.get(chat_id, 0)
+        await self._do_search(update, context, pending.query, generation)
 
     async def _handle_spotify_page(self, update, context, chat_id: int, data: str):
         """Handle Spotify page navigation (◀️ / ▶️)."""
@@ -694,13 +771,13 @@ class MusicBot:
             parse_mode=ParseMode.MARKDOWN,
         )
 
-        # Send a new message for the slskd search progress
         searching_msg = await context.bot.send_message(
             chat_id=chat_id,
             text="🔍 Searching slskd for FLAC...",
             parse_mode=ParseMode.MARKDOWN,
         )
-        await self._do_slskd_search(context, chat_id, track, searching_msg)
+        generation = self._chat_generation.get(chat_id, 0)
+        await self._do_slskd_search(context, chat_id, track, searching_msg, generation)
 
     async def _handle_results_page(self, update, context, chat_id: int, data: str):
         """Handle slskd results page navigation (◀️ / ▶️)."""
@@ -758,8 +835,14 @@ class MusicBot:
         result = pending.results[index]
         track = pending.track
 
-        # DON'T edit the results message — send a NEW message for this download
-        # The results keyboard stays active so user can pick more files
+        # Lock the results keyboard so no more selections can be made.
+        del self.pending[chat_id]
+        await _safe_edit(
+            query.message,
+            f"🎵 *{track.artist} - {track.title}*\nSelected #{index + 1}: `{_escape_md(result.basename)}`",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+
         status_msg = await context.bot.send_message(
             chat_id=chat_id,
             text=(
@@ -771,11 +854,11 @@ class MusicBot:
             parse_mode=ParseMode.MARKDOWN,
         )
 
-        # Run download in background so user can select more files
-        context.application.create_task(
+        task = context.application.create_task(
             self._do_download(context, chat_id, track, result, status_msg, index),
             update=update,
         )
+        self._track_task(chat_id, task)
 
     # =========================================================================
     # DOWNLOAD + PREVIEW + APPROVAL
@@ -794,7 +877,6 @@ class MusicBot:
         label = f"#{result_index + 1}"
 
         try:
-            # Enqueue download in slskd
             success = self.slskd.enqueue_download(result)
             if not success:
                 await status_msg.edit_text(
@@ -803,7 +885,6 @@ class MusicBot:
                 )
                 return
 
-            # Wait for download to complete
             status = await self.slskd.wait_for_download(
                 username=result.username,
                 filename=result.filename,
@@ -819,7 +900,6 @@ class MusicBot:
                 self._add_history(track, result, "failed")
                 return
 
-            # Find the downloaded file on disk
             source_path = self.processor.find_downloaded_file(result.username, result.filename)
             if not source_path:
                 await status_msg.edit_text(
@@ -828,80 +908,46 @@ class MusicBot:
                 self._add_history(track, result, "file_not_found")
                 return
 
-            # Run FLAC authenticity analysis (spectral cutoff detection)
             flac_verdict = await self._analyze_flac(source_path) if result.extension == "flac" else None
 
-            # Store as pending download for approval
             pending_dl = PendingDownload(
                 track=track,
                 result=result,
+                chat_id=chat_id,
                 source_path=source_path,
                 status_message_id=status_msg.message_id,
             )
             self.downloads[dl_id] = pending_dl
 
-            # Build quality + analysis line
             quality_line = f"Quality: {result.quality_display} | {result.duration_display}"
             if flac_verdict:
                 quality_line += f"\n{flac_verdict.display}"
 
-            # Update status message
             await status_msg.edit_text(
                 f"✅ *{label} Downloaded!* Sending preview...\n`{result.basename}`\n{quality_line}",
                 parse_mode=ParseMode.MARKDOWN,
             )
 
-            # Send the file to Telegram for preview
             file_size = os.path.getsize(source_path) if os.path.isfile(source_path) else 0
             caption = f"{label} {quality_line}\nSave to library?"
 
             if file_size > TELEGRAM_FILE_LIMIT:
-                # File too large to send directly — create a 30s preview clip
-                preview_path = await self._create_preview(source_path)
-                if preview_path:
-                    try:
-                        target_name = self.processor.build_filename(
-                            track.artist, f"{track.title} (30s preview)", result.extension
-                        )
-                        preview_caption = (
-                            f"🎧 {label} 30s preview "
-                            f"(full file: {file_size / (1024 * 1024):.0f}MB)\n"
-                            f"{quality_line}\n"
-                            f"Save to library?"
-                        )
-                        with open(preview_path, "rb") as f:
-                            await context.bot.send_audio(
-                                chat_id=chat_id,
-                                audio=f,
-                                filename=target_name,
-                                title=f"{track.title} (30s preview)",
-                                performer=track.artist,
-                                duration=30,
-                                caption=preview_caption,
-                                reply_markup=build_approve_keyboard(dl_id),
-                            )
-                    finally:
-                        # Clean up preview file
-                        with contextlib.suppress(OSError):
-                            os.unlink(preview_path)
-                else:
-                    # Preview creation failed — fall back to text-only message
-                    await context.bot.send_message(
-                        chat_id=chat_id,
-                        text=(
-                            f"📁 {label} File too large for Telegram "
-                            f"({file_size / (1024 * 1024):.0f}MB > 50MB limit).\n"
-                            f"{quality_line}\n\n"
-                            f"Save to library?"
-                        ),
-                        reply_markup=build_approve_keyboard(dl_id),
-                    )
+                await self._send_large_file(
+                    context,
+                    chat_id,
+                    track,
+                    result,
+                    source_path,
+                    file_size,
+                    quality_line,
+                    label,
+                    dl_id,
+                )
             else:
                 target_name = self.processor.build_filename(track.artist, track.title, result.extension)
                 try:
-                    # Try sending as playable audio first
                     with open(source_path, "rb") as f:
-                        await context.bot.send_audio(
+                        sent = await context.bot.send_audio(
                             chat_id=chat_id,
                             audio=f,
                             filename=target_name,
@@ -912,23 +958,125 @@ class MusicBot:
                             reply_markup=build_approve_keyboard(dl_id),
                         )
                 except BadRequest:
-                    # Fallback: send as document (works for some edge cases)
                     logger.info("send_audio failed, falling back to send_document for %s", result.basename)
                     with open(source_path, "rb") as f:
-                        await context.bot.send_document(
+                        sent = await context.bot.send_document(
                             chat_id=chat_id,
                             document=f,
                             filename=target_name,
                             caption=caption,
                             reply_markup=build_approve_keyboard(dl_id),
                         )
+                if dl_id in self.downloads:
+                    self.downloads[dl_id].approval_message_id = sent.message_id
 
+        except asyncio.CancelledError:
+            logger.info("Download cancelled for %s", result.basename)
+            self.downloads.pop(dl_id, None)
+            raise
         except Exception:
             logger.exception(f"Download failed for {result.basename}")
             await status_msg.edit_text(
                 f"❌ Error downloading `{result.basename}`. Check logs.",
                 parse_mode=ParseMode.MARKDOWN,
             )
+
+    async def _send_large_file(
+        self,
+        context,
+        chat_id: int,
+        track: TrackInfo,
+        result: SearchResult,
+        source_path: str,
+        file_size: int,
+        quality_line: str,
+        label: str,
+        dl_id: str,
+    ):
+        """Convert a >50 MB file to OGG and send.  Trim only as last resort.
+
+        Strategy:
+        1. Convert full song to OGG Opus (~128 kbps).
+        2. If OGG ≤ 50 MB → send the full song.
+        3. If OGG > 50 MB → trim to ~1 min and send that.
+        """
+        # Step 1: full OGG conversion
+        ogg_path = await self._convert_to_ogg(source_path)
+
+        if ogg_path:
+            ogg_size = os.path.getsize(ogg_path)
+            if ogg_size <= TELEGRAM_FILE_LIMIT:
+                try:
+                    target_name = self.processor.build_filename(track.artist, track.title, "ogg")
+                    caption = (
+                        f"🎧 {label} Converted to OGG "
+                        f"(original: {file_size / (1024 * 1024):.0f}MB {result.extension.upper()})\n"
+                        f"{quality_line}\nSave to library?"
+                    )
+                    with open(ogg_path, "rb") as f:
+                        sent = await context.bot.send_audio(
+                            chat_id=chat_id,
+                            audio=f,
+                            filename=target_name,
+                            title=track.title,
+                            performer=track.artist,
+                            duration=track.duration_secs,
+                            caption=caption,
+                            reply_markup=build_approve_keyboard(dl_id),
+                        )
+                    if dl_id in self.downloads:
+                        self.downloads[dl_id].approval_message_id = sent.message_id
+                    return
+                finally:
+                    with contextlib.suppress(OSError):
+                        os.unlink(ogg_path)
+            else:
+                # Full OGG still too large — clean up, will trim below.
+                with contextlib.suppress(OSError):
+                    os.unlink(ogg_path)
+
+        # Step 2: trim to ~1 min
+        preview_path = await self._create_preview(source_path, duration_secs=60.0)
+        if not preview_path:
+            logger.error("Preview creation failed for %s, cannot send to Telegram", source_path)
+            sent = await context.bot.send_message(
+                chat_id=chat_id,
+                text=(
+                    f"❌ {label} Could not create preview for "
+                    f"{file_size / (1024 * 1024):.0f}MB file.\n"
+                    f"{quality_line}\n\nSave to library anyway?"
+                ),
+                reply_markup=build_approve_keyboard(dl_id),
+            )
+            if dl_id in self.downloads:
+                self.downloads[dl_id].approval_message_id = sent.message_id
+            return
+
+        try:
+            preview_ext = os.path.splitext(preview_path)[1].lstrip(".")
+            target_name = self.processor.build_filename(track.artist, f"{track.title} (1min preview)", preview_ext)
+            preview_caption = (
+                f"🎧 {label} ~1 min preview "
+                f"(full file: {file_size / (1024 * 1024):.0f}MB)\n"
+                f"{quality_line}\n"
+                f"Save to library?"
+            )
+            with open(preview_path, "rb") as f:
+                sent = await context.bot.send_audio(
+                    chat_id=chat_id,
+                    audio=f,
+                    filename=target_name,
+                    title=f"{track.title} (1min preview)",
+                    performer=track.artist,
+                    duration=60,
+                    caption=preview_caption,
+                    reply_markup=build_approve_keyboard(dl_id),
+                )
+            if dl_id in self.downloads:
+                self.downloads[dl_id].approval_message_id = sent.message_id
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(preview_path)
 
     async def _handle_approval(self, update, context, chat_id: int, data: str):
         """Handle approve/reject of a downloaded file."""
@@ -937,14 +1085,13 @@ class MusicBot:
 
         pending_dl = self.downloads.pop(dl_id, None)
         if not pending_dl:
-            await query.edit_message_reply_markup(reply_markup=None)
+            await self._edit_approval_message(query, "⏹ Cancelled")
             return
 
         track = pending_dl.track
         result = pending_dl.result
 
         if action == "approve":
-            # Copy to output directory with proper naming
             if pending_dl.source_path:
                 target_path = self.processor.process_file(pending_dl.source_path, track.artist, track.title)
                 if target_path:
@@ -953,6 +1100,9 @@ class MusicBot:
                     await self._edit_approval_message(query, f"✅ Saved: `{target_name}`")
                     self._add_history(track, result, "success")
                     logger.info(f"Approved and saved: {target_name}")
+
+                    # Dismiss every other pending download for this chat.
+                    await self._dismiss_other_downloads(context, chat_id)
                 else:
                     await self._edit_approval_message(query, "❌ Failed to save file. Check logs.")
                     self._add_history(track, result, "process_failed")
@@ -965,15 +1115,37 @@ class MusicBot:
             self._add_history(track, result, "rejected")
             logger.info(f"Rejected: {track.artist} - {track.title} ({result.basename})")
 
+    async def _dismiss_other_downloads(self, context, chat_id: int):
+        """Cancel all remaining pending downloads for a chat after one is approved."""
+        stale = [(k, v) for k, v in self.downloads.items() if v.chat_id == chat_id]
+        for dl_id, dl in stale:
+            del self.downloads[dl_id]
+            if dl.approval_message_id:
+                try:
+                    await context.bot.edit_message_caption(
+                        chat_id=chat_id,
+                        message_id=dl.approval_message_id,
+                        caption="⏹ Cancelled",
+                    )
+                except Exception:
+                    with contextlib.suppress(Exception):
+                        await context.bot.edit_message_text(
+                            chat_id=chat_id,
+                            message_id=dl.approval_message_id,
+                            text="⏹ Cancelled",
+                        )
+
+        for task in self._active_tasks.pop(chat_id, set()):
+            task.cancel()
+
     @staticmethod
     async def _edit_approval_message(query, text: str):
         """Edit the approval message — works for both audio captions and text messages."""
         try:
-            # Try editing as audio caption first
             await query.edit_message_caption(caption=text, parse_mode=ParseMode.MARKDOWN)
         except Exception:
-            # Fall back to editing as text message (for files > 50MB)
-            await query.edit_message_text(text=text, parse_mode=ParseMode.MARKDOWN)
+            with contextlib.suppress(Exception):
+                await query.edit_message_text(text=text, parse_mode=ParseMode.MARKDOWN)
 
     # =========================================================================
     # FLAC ANALYSIS
@@ -982,8 +1154,6 @@ class MusicBot:
     @staticmethod
     async def _analyze_flac(filepath: str) -> FlacVerdict | None:
         """Run spectral analysis on a FLAC file in a thread to avoid blocking."""
-        import asyncio
-
         try:
             verdict = await asyncio.to_thread(analyze_flac, filepath)
             if verdict:
@@ -994,10 +1164,17 @@ class MusicBot:
             return None
 
     @staticmethod
-    async def _create_preview(filepath: str, duration_secs: float = 30.0) -> str | None:
-        """Create a short audio preview clip in a thread to avoid blocking."""
-        import asyncio
+    async def _convert_to_ogg(filepath: str) -> str | None:
+        """Convert a full audio file to OGG Opus in a thread."""
+        try:
+            return await asyncio.to_thread(convert_to_ogg, filepath)
+        except Exception:
+            logger.exception("OGG conversion failed for %s", filepath)
+            return None
 
+    @staticmethod
+    async def _create_preview(filepath: str, duration_secs: float = 60.0) -> str | None:
+        """Create a trimmed audio preview clip in a thread to avoid blocking."""
         try:
             return await asyncio.to_thread(create_preview_clip, filepath, duration_secs)
         except Exception:
@@ -1006,8 +1183,6 @@ class MusicBot:
 
     async def _embed_spotify_artwork(self, filepath: str, track: TrackInfo) -> None:
         """Fetch album artwork from Spotify and embed into the saved file."""
-        import asyncio
-
         try:
             art = await asyncio.to_thread(fetch_spotify_artwork, self.spotify.sp, track.artist, track.title)
             if art:

--- a/src/music_downloader/processor/flac_analyzer.py
+++ b/src/music_downloader/processor/flac_analyzer.py
@@ -14,6 +14,7 @@ Verdicts:
     FAKE       - cutoff <17 kHz (definitely transcoded from lossy)
 """
 
+import contextlib
 import logging
 import os
 import re
@@ -172,46 +173,141 @@ def analyze_flac(filepath: str, sample_duration: float = 30.0) -> FlacVerdict | 
         return None
 
 
-def create_preview_clip(filepath: str, duration_secs: float = 30.0) -> str | None:
+def convert_to_ogg(filepath: str) -> str | None:
     """
-    Extract a short preview clip from an audio file in the same format.
+    Convert a full audio file to OGG Opus using ffmpeg.
 
-    Reads *duration_secs* starting at 20% into the track (to skip
-    intros/silence) and writes a temporary file in the same format
-    and encoding as the original.
+    Preserves the entire duration — no trimming.  Output is typically
+    much smaller than lossless sources (a 60 MB FLAC becomes ~5 MB OGG
+    at 128 kbps).
 
     Args:
         filepath: Path to the source audio file.
-        duration_secs: Length of the preview clip in seconds.
 
     Returns:
-        Path to the temporary preview file, or None on error.
+        Path to the temporary ``.ogg`` file, or None on error.
         Caller is responsible for deleting the file after use.
     """
+    import subprocess
+
+    ogg_path = None
     try:
-        info = sf.info(filepath)
-        sr = info.samplerate
-        total_frames = info.frames
-
-        # Start at 20% of the track (skip intros, find recognisable content)
-        start_frame = int(total_frames * 0.2)
-        frames_to_read = min(int(sr * duration_secs), total_frames - start_frame)
-
-        if frames_to_read <= 0:
-            # Track is shorter than the requested clip — just use the whole thing
-            # (caller shouldn't need a preview for a tiny file, but handle it)
-            start_frame = 0
-            frames_to_read = total_frames
-
-        data, _ = sf.read(filepath, start=start_frame, frames=frames_to_read, always_2d=True)
-
-        # Write to a temp file in the same format
-        ext = os.path.splitext(filepath)[1].lower() or ".flac"
-        fd, preview_path = tempfile.mkstemp(suffix=ext)
+        fd, ogg_path = tempfile.mkstemp(suffix=".ogg")
         os.close(fd)
 
-        sf.write(preview_path, data, sr, subtype=info.subtype)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                filepath,
+                "-c:a",
+                "libopus",
+                "-b:a",
+                "128k",
+                "-vn",
+                "-map_metadata",
+                "-1",
+                ogg_path,
+            ],
+            capture_output=True,
+            timeout=300,
+            check=True,
+        )
+
+        ogg_size = os.path.getsize(ogg_path)
+        if ogg_size == 0:
+            os.unlink(ogg_path)
+            return None
+
+        logger.info(
+            "Converted to OGG Opus: %s (%.1f MB)",
+            ogg_path,
+            ogg_size / (1024 * 1024),
+        )
+        return ogg_path
+
+    except Exception:
+        logger.exception("Failed to convert to OGG: %s", filepath)
+        if ogg_path:
+            with contextlib.suppress(OSError):
+                os.unlink(ogg_path)
+        return None
+
+
+def create_preview_clip(filepath: str, duration_secs: float = 60.0) -> str | None:
+    """
+    Extract a trimmed OGG Opus clip from any audio file using ffmpeg.
+
+    Starts at 20 % into the track (to skip intros/silence) and takes
+    *duration_secs* of audio.
+
+    Args:
+        filepath: Path to the source audio file.
+        duration_secs: Length of the clip in seconds (default 60).
+
+    Returns:
+        Path to the temporary ``.ogg`` preview file, or None on error.
+        Caller is responsible for deleting the file after use.
+    """
+    import json
+    import subprocess
+
+    preview_path = None
+    try:
+        total_duration = 0.0
+        probe = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_format",
+                filepath,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if probe.returncode == 0:
+            fmt = json.loads(probe.stdout).get("format", {})
+            total_duration = float(fmt.get("duration", 0))
+
+        start_secs = total_duration * 0.2 if total_duration > 0 else 0
+
+        fd, preview_path = tempfile.mkstemp(suffix=".ogg")
+        os.close(fd)
+
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                f"{start_secs:.2f}",
+                "-i",
+                filepath,
+                "-t",
+                f"{duration_secs:.2f}",
+                "-c:a",
+                "libopus",
+                "-b:a",
+                "128k",
+                "-vn",
+                "-map_metadata",
+                "-1",
+                preview_path,
+            ],
+            capture_output=True,
+            timeout=120,
+            check=True,
+        )
+
         preview_size = os.path.getsize(preview_path)
+        if preview_size == 0:
+            os.unlink(preview_path)
+            return None
+
         logger.info(
             "Created %ds preview clip: %s (%.1f MB)",
             duration_secs,
@@ -222,4 +318,7 @@ def create_preview_clip(filepath: str, duration_secs: float = 30.0) -> str | Non
 
     except Exception:
         logger.exception("Failed to create preview clip for: %s", filepath)
+        if preview_path:
+            with contextlib.suppress(OSError):
+                os.unlink(preview_path)
         return None

--- a/src/music_downloader/search/slskd_client.py
+++ b/src/music_downloader/search/slskd_client.py
@@ -222,7 +222,9 @@ class SlskdClient:
         # Try both retrieval methods — each silently returns empty under
         # different conditions (large payloads vs. timing).
         final_state = await asyncio.to_thread(
-            self.client.searches.state, id=search_id, includeResponses=True,
+            self.client.searches.state,
+            id=search_id,
+            includeResponses=True,
         )
         responses: list[dict] = final_state.get("responses", [])
 
@@ -233,11 +235,13 @@ class SlskdClient:
                 logger.info(
                     "state(includeResponses) empty despite %d peers / %d files — "
                     "falling back to search_responses endpoint",
-                    resp_count, file_count,
+                    resp_count,
+                    file_count,
                 )
                 with contextlib.suppress(Exception):
                     responses = await asyncio.to_thread(
-                        self.client.searches.search_responses, id=search_id,
+                        self.client.searches.search_responses,
+                        id=search_id,
                     )
                 logger.info("search_responses returned %d responses", len(responses))
 
@@ -253,13 +257,16 @@ class SlskdClient:
             await asyncio.to_thread(self.client.searches.stop, id=search_id)
         try:
             final_state = await asyncio.to_thread(
-                self.client.searches.state, id=search_id, includeResponses=True,
+                self.client.searches.state,
+                id=search_id,
+                includeResponses=True,
             )
             responses: list[dict] = final_state.get("responses", [])
             if not responses and final_state.get("responseCount", 0) > 0:
                 with contextlib.suppress(Exception):
                     responses = await asyncio.to_thread(
-                        self.client.searches.search_responses, id=search_id,
+                        self.client.searches.search_responses,
+                        id=search_id,
                     )
         except Exception:
             logger.exception(f"Failed to collect partial results for {search_id}")

--- a/src/music_downloader/tools/artwork_embedder.py
+++ b/src/music_downloader/tools/artwork_embedder.py
@@ -108,9 +108,7 @@ def _embed_flac(path: str, image_data: bytes) -> bool:
 def _embed_m4a(path: str, image_data: bytes) -> bool:
     try:
         f = mutagen.mp4.MP4(path)
-        f.tags["covr"] = [
-            mutagen.mp4.MP4Cover(image_data, imageformat=mutagen.mp4.MP4Cover.FORMAT_JPEG)
-        ]
+        f.tags["covr"] = [mutagen.mp4.MP4Cover(image_data, imageformat=mutagen.mp4.MP4Cover.FORMAT_JPEG)]
         f.save()
         return True
     except Exception:
@@ -142,9 +140,7 @@ def run(
         logger.error("SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET must be set")
         sys.exit(1)
 
-    sp = spotipy.Spotify(
-        auth_manager=SpotifyClientCredentials(client_id=client_id, client_secret=client_secret)
-    )
+    sp = spotipy.Spotify(auth_manager=SpotifyClientCredentials(client_id=client_id, client_secret=client_secret))
 
     flac_files = sorted(f for f in os.listdir(music_dir) if f.lower().endswith(".flac"))
     logger.info("Found %d FLAC files in %s", len(flac_files), music_dir)

--- a/src/music_downloader/tools/embed_artwork.py
+++ b/src/music_downloader/tools/embed_artwork.py
@@ -56,9 +56,7 @@ def embed_artwork_into_file(filepath: str, image_data: bytes) -> bool:
             f = mutagen.mp4.MP4(filepath)
             if f.tags and f.tags.get("covr"):
                 return False
-            f.tags["covr"] = [
-                mutagen.mp4.MP4Cover(image_data, imageformat=mutagen.mp4.MP4Cover.FORMAT_JPEG)
-            ]
+            f.tags["covr"] = [mutagen.mp4.MP4Cover(image_data, imageformat=mutagen.mp4.MP4Cover.FORMAT_JPEG)]
             f.save()
             return True
         else:

--- a/tests/test_flac_analyzer.py
+++ b/tests/test_flac_analyzer.py
@@ -6,7 +6,7 @@ import tempfile
 import numpy as np
 import soundfile as sf
 
-from music_downloader.processor.flac_analyzer import FlacVerdict, analyze_flac, create_preview_clip
+from music_downloader.processor.flac_analyzer import FlacVerdict, analyze_flac, convert_to_ogg, create_preview_clip
 
 
 class TestFlacVerdict:
@@ -155,10 +155,10 @@ class TestCreatePreviewClip:
             preview_size = os.path.getsize(preview_path)
             assert preview_size < original_size * 0.5
 
-            # Verify the preview file is valid audio
+            # Verify the preview is valid OGG Opus audio (always 48 kHz)
             info = sf.info(preview_path)
-            assert info.samplerate == 44100
-            # Duration should be ~30s (allow small tolerance)
+            assert info.samplerate == 48000
+            assert preview_path.endswith(".ogg")
             preview_duration = info.frames / info.samplerate
             assert 29.0 <= preview_duration <= 31.0
 
@@ -189,18 +189,58 @@ class TestCreatePreviewClip:
         result = create_preview_clip("/tmp/nonexistent_preview_test.flac")
         assert result is None
 
-    def test_preview_preserves_sample_rate(self):
-        """Preview should keep the original sample rate."""
+    def test_preview_outputs_ogg_opus(self):
+        """Preview always outputs OGG Opus at 48 kHz regardless of source sample rate."""
         with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as f:
             path = f.name
         try:
             self._create_test_flac(path, sample_rate=96000, duration=60.0)
             preview_path = create_preview_clip(path, duration_secs=30.0)
             assert preview_path is not None
+            assert preview_path.endswith(".ogg")
 
             info = sf.info(preview_path)
-            assert info.samplerate == 96000
+            assert info.samplerate == 48000
 
             os.unlink(preview_path)
         finally:
             os.unlink(path)
+
+
+class TestConvertToOgg:
+    """Test convert_to_ogg function."""
+
+    @staticmethod
+    def _create_test_flac(filepath: str, duration: float = 60.0):
+        rng = np.random.default_rng(42)
+        n_samples = int(44100 * duration)
+        data = (rng.standard_normal(n_samples) * 0.3).astype(np.float32)
+        sf.write(filepath, data, 44100, subtype="PCM_16")
+
+    def test_converts_full_song(self):
+        """Full conversion preserves the entire duration."""
+        with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as f:
+            path = f.name
+        try:
+            self._create_test_flac(path, duration=120.0)
+            original_size = os.path.getsize(path)
+
+            ogg_path = convert_to_ogg(path)
+            assert ogg_path is not None
+            assert ogg_path.endswith(".ogg")
+            assert os.path.isfile(ogg_path)
+
+            ogg_size = os.path.getsize(ogg_path)
+            assert ogg_size < original_size
+
+            info = sf.info(ogg_path)
+            ogg_duration = info.frames / info.samplerate
+            assert 118.0 <= ogg_duration <= 122.0
+
+            os.unlink(ogg_path)
+        finally:
+            os.unlink(path)
+
+    def test_nonexistent_file_returns_none(self):
+        result = convert_to_ogg("/tmp/nonexistent_ogg_test.flac")
+        assert result is None


### PR DESCRIPTION
## Summary

- **Cancel-on-message**: sending a new query while mid-search or mid-download cancels all in-flight operations instantly (generation counter + asyncio task cancellation)
- **OGG conversion for large files**: files >50 MB are converted to OGG Opus via ffmpeg and sent in full; only trimmed to ~1 min if OGG still exceeds 50 MB
- **Dismiss-on-approve**: saving one download to library automatically cancels all other pending downloads (buttons removed, messages updated to "Cancelled")
- **Results keyboard lock**: selecting a download removes the results keyboard to prevent duplicate picks
- **ffmpeg in Docker**: added as system dependency for reliable audio conversion (replaces soundfile for previews)

## Test plan

- [x] All 58 tests pass locally
- [ ] GHA lint passes
- [ ] GHA tests pass
- [ ] Manual test: send query mid-download → old operation cancelled, new search starts
- [ ] Manual test: large FLAC file (>50 MB) → sent as full OGG Opus
- [ ] Manual test: approve one download → other pending downloads show "Cancelled"