### PR TITLE
ci: add codecov.yml with 90% coverage target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,39 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 2%
+    patch:
+      default:
+        target: 90%
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+ignore:
+  - "**/__pycache__/**"
+  - "dist/**"
+  - "build/**"
+  - ".venv/**"
+  - "venv/**"
+  - "coverage/**"
+  - "**/test_*.py"
+  - "**/*_test.py"
+  - "**/conftest.py"
+  - "tests/**"
+  - "test/**"
+  - "setup.py"
+  - "setup.cfg"
+  - "**/*.config.*"


### PR DESCRIPTION
Adds a `codecov.yml` configuration file enforcing a **90% coverage target** for both project and patch coverage.

Language: **python** — includes language-specific ignore patterns for test files, build artifacts, and generated code.