### PR TITLE
test: improve test coverage to 93%

### DIFF
--- a/tests/test_artwork_embedder.py
+++ b/tests/test_artwork_embedder.py
@@ -1,0 +1,337 @@
+"""Tests for batch artwork embedder module."""
+
+import os
+import struct
+from unittest.mock import MagicMock, patch
+
+import mutagen.flac
+import pytest
+
+from music_downloader.tools.artwork_embedder import (
+    _download_image,
+    _embed_flac,
+    _embed_m4a,
+    _fetch_spotify_artwork_url,
+    _flac_has_art,
+    _m4a_has_art,
+    _parse_artist_title,
+    _sibling_m4a_path,
+    run,
+)
+
+
+def _create_test_flac(path: str, tags: dict | None = None, with_art: bool = False) -> None:
+    """Create a minimal valid FLAC file."""
+    streaminfo = bytes(
+        [
+            0x10, 0x00, 0x10, 0x00,
+            0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00,
+            0x0A, 0xC4, 0x42, 0xF0,
+            0x00, 0x00, 0x00, 0x00,
+        ]
+        + [0x00] * 16
+    )
+    streaminfo_header = struct.pack(">I", (0x00 << 24) | 34)
+    padding_header = struct.pack(">I", (0x81 << 24) | 0)
+    with open(path, "wb") as f:
+        f.write(b"fLaC")
+        f.write(streaminfo_header)
+        f.write(streaminfo)
+        f.write(padding_header)
+
+    audio = mutagen.flac.FLAC(path)
+    if tags:
+        for k, v in tags.items():
+            audio[k] = v
+    if with_art:
+        pic = mutagen.flac.Picture()
+        pic.type = 3
+        pic.mime = "image/jpeg"
+        pic.desc = "Cover"
+        pic.data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        audio.add_picture(pic)
+    audio.save()
+
+
+class TestParseArtistTitle:
+    def test_standard_format(self):
+        result = _parse_artist_title("Nancy Sinatra - Bang Bang.flac")
+        assert result == ("Nancy Sinatra", "Bang Bang")
+
+    def test_with_path(self):
+        result = _parse_artist_title("/music/Nancy Sinatra - Bang Bang.flac")
+        assert result == ("Nancy Sinatra", "Bang Bang")
+
+    def test_no_separator(self):
+        result = _parse_artist_title("JustAFilename.flac")
+        assert result is None
+
+    def test_multiple_dashes(self):
+        result = _parse_artist_title("Artist - Title - Extra.flac")
+        assert result is not None
+        assert result[0] == "Artist"
+
+
+class TestFlacHasArt:
+    def test_has_art(self, tmp_path):
+        path = str(tmp_path / "art.flac")
+        _create_test_flac(path, with_art=True)
+        assert _flac_has_art(path) is True
+
+    def test_no_art(self, tmp_path):
+        path = str(tmp_path / "noart.flac")
+        _create_test_flac(path, with_art=False)
+        assert _flac_has_art(path) is False
+
+    def test_invalid_file(self, tmp_path):
+        path = str(tmp_path / "bad.flac")
+        with open(path, "w") as f:
+            f.write("not a flac")
+        assert _flac_has_art(path) is False
+
+
+class TestM4aHasArt:
+    def test_invalid_file(self, tmp_path):
+        path = str(tmp_path / "bad.m4a")
+        with open(path, "w") as f:
+            f.write("not m4a")
+        assert _m4a_has_art(path) is False
+
+    def test_with_art(self):
+        with patch("music_downloader.tools.artwork_embedder.mutagen.mp4.MP4") as mock:
+            mock_file = MagicMock()
+            tags_mock = MagicMock()
+            tags_mock.get.return_value = [b"data"]
+            mock_file.tags = tags_mock
+            mock.return_value = mock_file
+            assert _m4a_has_art("test.m4a") is True
+
+    def test_no_art(self):
+        with patch("music_downloader.tools.artwork_embedder.mutagen.mp4.MP4") as mock:
+            mock_file = MagicMock()
+            tags_mock = MagicMock()
+            tags_mock.get.return_value = []
+            mock_file.tags = tags_mock
+            mock.return_value = mock_file
+            assert _m4a_has_art("test.m4a") is False
+
+
+class TestFetchSpotifyArtworkUrl:
+    def test_returns_url(self):
+        mock_sp = MagicMock()
+        mock_sp.search.return_value = {
+            "tracks": {
+                "items": [
+                    {"album": {"images": [{"url": "https://i.scdn.co/image/abc"}]}}
+                ]
+            }
+        }
+        result = _fetch_spotify_artwork_url(mock_sp, "Artist", "Title")
+        assert result == "https://i.scdn.co/image/abc"
+
+    def test_no_tracks(self):
+        mock_sp = MagicMock()
+        mock_sp.search.return_value = {"tracks": {"items": []}}
+        assert _fetch_spotify_artwork_url(mock_sp, "A", "T") is None
+
+    def test_no_images(self):
+        mock_sp = MagicMock()
+        mock_sp.search.return_value = {
+            "tracks": {"items": [{"album": {"images": []}}]}
+        }
+        assert _fetch_spotify_artwork_url(mock_sp, "A", "T") is None
+
+    def test_exception(self):
+        mock_sp = MagicMock()
+        mock_sp.search.side_effect = Exception("API fail")
+        assert _fetch_spotify_artwork_url(mock_sp, "A", "T") is None
+
+
+class TestDownloadImage:
+    def test_success(self):
+        with patch("music_downloader.tools.artwork_embedder.httpx") as mock_httpx:
+            mock_resp = MagicMock()
+            mock_resp.content = b"\xff\xd8\xff\xe0"
+            mock_resp.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_resp
+            result = _download_image("https://example.com/art.jpg")
+            assert result == b"\xff\xd8\xff\xe0"
+
+    def test_failure(self):
+        with patch("music_downloader.tools.artwork_embedder.httpx") as mock_httpx:
+            mock_httpx.get.side_effect = Exception("timeout")
+            result = _download_image("https://example.com/art.jpg")
+            assert result is None
+
+
+class TestEmbedFlac:
+    def test_success(self, tmp_path):
+        path = str(tmp_path / "test.flac")
+        _create_test_flac(path)
+        result = _embed_flac(path, b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+        assert result is True
+        audio = mutagen.flac.FLAC(path)
+        assert len(audio.pictures) == 1
+
+    def test_invalid_file(self, tmp_path):
+        path = str(tmp_path / "bad.flac")
+        with open(path, "w") as f:
+            f.write("not flac")
+        result = _embed_flac(path, b"\x00")
+        assert result is False
+
+
+class TestEmbedM4a:
+    def test_success(self):
+        with patch("music_downloader.tools.artwork_embedder.mutagen.mp4.MP4") as mock:
+            mock_file = MagicMock()
+            mock_file.tags = {}
+            mock.return_value = mock_file
+            result = _embed_m4a("test.m4a", b"\xff\xd8\xff\xe0")
+            assert result is True
+
+    def test_failure(self):
+        with patch("music_downloader.tools.artwork_embedder.mutagen.mp4.MP4") as mock:
+            mock.side_effect = Exception("fail")
+            result = _embed_m4a("test.m4a", b"\xff\xd8\xff\xe0")
+            assert result is False
+
+
+class TestSiblingM4aPath:
+    def test_sibling_exists(self, tmp_path):
+        m4a = tmp_path / "Song.m4a"
+        m4a.write_text("data")
+        result = _sibling_m4a_path(str(tmp_path / "Song.flac"), str(tmp_path))
+        assert result is not None
+        assert result.endswith("Song.m4a")
+
+    def test_sibling_missing(self, tmp_path):
+        result = _sibling_m4a_path(str(tmp_path / "Song.flac"), str(tmp_path))
+        assert result is None
+
+
+class TestRun:
+    def test_run_dry_run(self, tmp_path):
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        flac_path = str(music_dir / "Artist - Title.flac")
+        _create_test_flac(flac_path)
+
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
+            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
+                stats = run(str(music_dir), dry_run=True)
+                assert stats["total"] == 1
+                assert stats["missing"] == 1
+                assert len(stats["skipped"]) == 1
+
+    def test_run_no_credentials_exits(self, tmp_path):
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "", "SPOTIFY_CLIENT_SECRET": ""}, clear=False):
+            with pytest.raises(SystemExit):
+                run(str(music_dir))
+
+    def test_run_embeds_artwork(self, tmp_path):
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        flac_path = str(music_dir / "Artist - Title.flac")
+        _create_test_flac(flac_path)
+
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
+            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
+                with patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url:
+                    mock_url.return_value = "https://example.com/art.jpg"
+                    with patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl:
+                        mock_dl.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+                        with patch("music_downloader.tools.artwork_embedder._embed_flac") as mock_embed:
+                            mock_embed.return_value = True
+                            with patch("music_downloader.tools.artwork_embedder.time.sleep"):
+                                stats = run(str(music_dir))
+                                assert stats["embedded"] == 1
+
+    def test_run_unparseable_filename(self, tmp_path):
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        flac_path = str(music_dir / "JustAFilename.flac")
+        _create_test_flac(flac_path)
+
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
+            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
+                stats = run(str(music_dir))
+                assert len(stats["failed"]) == 1
+
+    def test_run_no_spotify_artwork(self, tmp_path):
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        flac_path = str(music_dir / "Artist - Title.flac")
+        _create_test_flac(flac_path)
+
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
+            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
+                with patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url:
+                    mock_url.return_value = None
+                    with patch("music_downloader.tools.artwork_embedder.time.sleep"):
+                        stats = run(str(music_dir))
+                        assert len(stats["failed"]) == 1
+
+    def test_run_download_image_fails(self, tmp_path):
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        flac_path = str(music_dir / "Artist - Title.flac")
+        _create_test_flac(flac_path)
+
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
+            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
+                with patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url:
+                    mock_url.return_value = "https://example.com/art.jpg"
+                    with patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl:
+                        mock_dl.return_value = None
+                        stats = run(str(music_dir))
+                        assert len(stats["failed"]) == 1
+
+    def test_run_writes_report(self, tmp_path):
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        flac_path = str(music_dir / "NoSeparator.flac")
+        _create_test_flac(flac_path)
+        report_path = str(tmp_path / "report.txt")
+
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
+            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
+                run(str(music_dir), report_path=report_path)
+                assert os.path.isfile(report_path)
+
+    def test_run_with_aac_and_alac_dirs(self, tmp_path):
+        music_dir = tmp_path / "music"
+        aac_dir = tmp_path / "aac"
+        alac_dir = tmp_path / "alac"
+        music_dir.mkdir()
+        aac_dir.mkdir()
+        alac_dir.mkdir()
+
+        flac_path = str(music_dir / "Artist - Title.flac")
+        _create_test_flac(flac_path)
+        # Create sibling M4A in AAC dir
+        (aac_dir / "Artist - Title.m4a").write_bytes(b"\x00" * 100)
+
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
+            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
+                with patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url:
+                    mock_url.return_value = "https://example.com/art.jpg"
+                    with patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl:
+                        mock_dl.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+                        with patch("music_downloader.tools.artwork_embedder._embed_flac") as mock_ef:
+                            mock_ef.return_value = True
+                            with patch("music_downloader.tools.artwork_embedder._m4a_has_art") as mock_has:
+                                mock_has.return_value = False
+                                with patch("music_downloader.tools.artwork_embedder._embed_m4a") as mock_em:
+                                    mock_em.return_value = True
+                                    with patch("music_downloader.tools.artwork_embedder.time.sleep"):
+                                        stats = run(
+                                            str(music_dir),
+                                            aac_dir=str(aac_dir),
+                                            alac_dir=str(alac_dir),
+                                        )
+                                        assert stats["embedded"] == 1
+                                        mock_em.assert_called_once()

--- a/tests/test_artwork_embedder.py
+++ b/tests/test_artwork_embedder.py
@@ -24,11 +24,24 @@ def _create_test_flac(path: str, tags: dict | None = None, with_art: bool = Fals
     """Create a minimal valid FLAC file."""
     streaminfo = bytes(
         [
-            0x10, 0x00, 0x10, 0x00,
-            0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00,
-            0x0A, 0xC4, 0x42, 0xF0,
-            0x00, 0x00, 0x00, 0x00,
+            0x10,
+            0x00,
+            0x10,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x0A,
+            0xC4,
+            0x42,
+            0xF0,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
         ]
         + [0x00] * 16
     )
@@ -121,11 +134,7 @@ class TestFetchSpotifyArtworkUrl:
     def test_returns_url(self):
         mock_sp = MagicMock()
         mock_sp.search.return_value = {
-            "tracks": {
-                "items": [
-                    {"album": {"images": [{"url": "https://i.scdn.co/image/abc"}]}}
-                ]
-            }
+            "tracks": {"items": [{"album": {"images": [{"url": "https://i.scdn.co/image/abc"}]}}]}
         }
         result = _fetch_spotify_artwork_url(mock_sp, "Artist", "Title")
         assert result == "https://i.scdn.co/image/abc"
@@ -137,9 +146,7 @@ class TestFetchSpotifyArtworkUrl:
 
     def test_no_images(self):
         mock_sp = MagicMock()
-        mock_sp.search.return_value = {
-            "tracks": {"items": [{"album": {"images": []}}]}
-        }
+        mock_sp.search.return_value = {"tracks": {"items": [{"album": {"images": []}}]}}
         assert _fetch_spotify_artwork_url(mock_sp, "A", "T") is None
 
     def test_exception(self):
@@ -230,7 +237,10 @@ class TestRun:
     def test_run_no_credentials_exits(self, tmp_path):
         music_dir = tmp_path / "music"
         music_dir.mkdir()
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "", "SPOTIFY_CLIENT_SECRET": ""}, clear=False), pytest.raises(SystemExit):
+        with (
+            patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "", "SPOTIFY_CLIENT_SECRET": ""}, clear=False),
+            pytest.raises(SystemExit),
+        ):
             run(str(music_dir))
 
     def test_run_embeds_artwork(self, tmp_path):

--- a/tests/test_artwork_embedder.py
+++ b/tests/test_artwork_embedder.py
@@ -218,19 +218,20 @@ class TestRun:
         flac_path = str(music_dir / "Artist - Title.flac")
         _create_test_flac(flac_path)
 
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
-            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
-                stats = run(str(music_dir), dry_run=True)
-                assert stats["total"] == 1
-                assert stats["missing"] == 1
-                assert len(stats["skipped"]) == 1
+        with (
+            patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}),
+            patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"),
+        ):
+            stats = run(str(music_dir), dry_run=True)
+            assert stats["total"] == 1
+            assert stats["missing"] == 1
+            assert len(stats["skipped"]) == 1
 
     def test_run_no_credentials_exits(self, tmp_path):
         music_dir = tmp_path / "music"
         music_dir.mkdir()
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "", "SPOTIFY_CLIENT_SECRET": ""}, clear=False):
-            with pytest.raises(SystemExit):
-                run(str(music_dir))
+        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "", "SPOTIFY_CLIENT_SECRET": ""}, clear=False), pytest.raises(SystemExit):
+            run(str(music_dir))
 
     def test_run_embeds_artwork(self, tmp_path):
         music_dir = tmp_path / "music"
@@ -238,17 +239,19 @@ class TestRun:
         flac_path = str(music_dir / "Artist - Title.flac")
         _create_test_flac(flac_path)
 
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
-            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
-                with patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url:
-                    mock_url.return_value = "https://example.com/art.jpg"
-                    with patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl:
-                        mock_dl.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 100
-                        with patch("music_downloader.tools.artwork_embedder._embed_flac") as mock_embed:
-                            mock_embed.return_value = True
-                            with patch("music_downloader.tools.artwork_embedder.time.sleep"):
-                                stats = run(str(music_dir))
-                                assert stats["embedded"] == 1
+        with (
+            patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}),
+            patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"),
+            patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url,
+            patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl,
+            patch("music_downloader.tools.artwork_embedder._embed_flac") as mock_embed,
+            patch("music_downloader.tools.artwork_embedder.time.sleep"),
+        ):
+            mock_url.return_value = "https://example.com/art.jpg"
+            mock_dl.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+            mock_embed.return_value = True
+            stats = run(str(music_dir))
+            assert stats["embedded"] == 1
 
     def test_run_unparseable_filename(self, tmp_path):
         music_dir = tmp_path / "music"
@@ -256,10 +259,12 @@ class TestRun:
         flac_path = str(music_dir / "JustAFilename.flac")
         _create_test_flac(flac_path)
 
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
-            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
-                stats = run(str(music_dir))
-                assert len(stats["failed"]) == 1
+        with (
+            patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}),
+            patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"),
+        ):
+            stats = run(str(music_dir))
+            assert len(stats["failed"]) == 1
 
     def test_run_no_spotify_artwork(self, tmp_path):
         music_dir = tmp_path / "music"
@@ -267,13 +272,15 @@ class TestRun:
         flac_path = str(music_dir / "Artist - Title.flac")
         _create_test_flac(flac_path)
 
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
-            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
-                with patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url:
-                    mock_url.return_value = None
-                    with patch("music_downloader.tools.artwork_embedder.time.sleep"):
-                        stats = run(str(music_dir))
-                        assert len(stats["failed"]) == 1
+        with (
+            patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}),
+            patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"),
+            patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url,
+            patch("music_downloader.tools.artwork_embedder.time.sleep"),
+        ):
+            mock_url.return_value = None
+            stats = run(str(music_dir))
+            assert len(stats["failed"]) == 1
 
     def test_run_download_image_fails(self, tmp_path):
         music_dir = tmp_path / "music"
@@ -281,14 +288,16 @@ class TestRun:
         flac_path = str(music_dir / "Artist - Title.flac")
         _create_test_flac(flac_path)
 
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
-            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
-                with patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url:
-                    mock_url.return_value = "https://example.com/art.jpg"
-                    with patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl:
-                        mock_dl.return_value = None
-                        stats = run(str(music_dir))
-                        assert len(stats["failed"]) == 1
+        with (
+            patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}),
+            patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"),
+            patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url,
+            patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl,
+        ):
+            mock_url.return_value = "https://example.com/art.jpg"
+            mock_dl.return_value = None
+            stats = run(str(music_dir))
+            assert len(stats["failed"]) == 1
 
     def test_run_writes_report(self, tmp_path):
         music_dir = tmp_path / "music"
@@ -297,10 +306,12 @@ class TestRun:
         _create_test_flac(flac_path)
         report_path = str(tmp_path / "report.txt")
 
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
-            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
-                run(str(music_dir), report_path=report_path)
-                assert os.path.isfile(report_path)
+        with (
+            patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}),
+            patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"),
+        ):
+            run(str(music_dir), report_path=report_path)
+            assert os.path.isfile(report_path)
 
     def test_run_with_aac_and_alac_dirs(self, tmp_path):
         music_dir = tmp_path / "music"
@@ -315,23 +326,25 @@ class TestRun:
         # Create sibling M4A in AAC dir
         (aac_dir / "Artist - Title.m4a").write_bytes(b"\x00" * 100)
 
-        with patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
-            with patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"):
-                with patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url:
-                    mock_url.return_value = "https://example.com/art.jpg"
-                    with patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl:
-                        mock_dl.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 100
-                        with patch("music_downloader.tools.artwork_embedder._embed_flac") as mock_ef:
-                            mock_ef.return_value = True
-                            with patch("music_downloader.tools.artwork_embedder._m4a_has_art") as mock_has:
-                                mock_has.return_value = False
-                                with patch("music_downloader.tools.artwork_embedder._embed_m4a") as mock_em:
-                                    mock_em.return_value = True
-                                    with patch("music_downloader.tools.artwork_embedder.time.sleep"):
-                                        stats = run(
-                                            str(music_dir),
-                                            aac_dir=str(aac_dir),
-                                            alac_dir=str(alac_dir),
-                                        )
-                                        assert stats["embedded"] == 1
-                                        mock_em.assert_called_once()
+        with (
+            patch.dict(os.environ, {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}),
+            patch("music_downloader.tools.artwork_embedder.spotipy.Spotify"),
+            patch("music_downloader.tools.artwork_embedder._fetch_spotify_artwork_url") as mock_url,
+            patch("music_downloader.tools.artwork_embedder._download_image") as mock_dl,
+            patch("music_downloader.tools.artwork_embedder._embed_flac") as mock_ef,
+            patch("music_downloader.tools.artwork_embedder._m4a_has_art") as mock_has,
+            patch("music_downloader.tools.artwork_embedder._embed_m4a") as mock_em,
+            patch("music_downloader.tools.artwork_embedder.time.sleep"),
+        ):
+            mock_url.return_value = "https://example.com/art.jpg"
+            mock_dl.return_value = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+            mock_ef.return_value = True
+            mock_has.return_value = False
+            mock_em.return_value = True
+            stats = run(
+                str(music_dir),
+                aac_dir=str(aac_dir),
+                alac_dir=str(alac_dir),
+            )
+            assert stats["embedded"] == 1
+            mock_em.assert_called_once()

--- a/tests/test_config_extended.py
+++ b/tests/test_config_extended.py
@@ -4,8 +4,6 @@ import logging
 import os
 from unittest.mock import patch
 
-import pytest
-
 from music_downloader.config import Config, setup_logging
 
 

--- a/tests/test_config_extended.py
+++ b/tests/test_config_extended.py
@@ -1,0 +1,61 @@
+"""Extended tests for config module - covering setup_logging and edge cases."""
+
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+from music_downloader.config import Config, setup_logging
+
+
+class TestSetupLogging:
+    def test_configures_logging(self):
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "SPOTIFY_CLIENT_ID": "s",
+            "SPOTIFY_CLIENT_SECRET": "ss",
+            "SLSKD_HOST": "h",
+            "SLSKD_API_KEY": "k",
+            "LOG_LEVEL": "DEBUG",
+        }, clear=False):
+            config = Config()
+            setup_logging(config)
+            assert logging.getLogger("httpx").level == logging.WARNING
+            assert logging.getLogger("httpcore").level == logging.WARNING
+            assert logging.getLogger("telegram").level == logging.WARNING
+            assert logging.getLogger("spotipy").level == logging.WARNING
+
+
+class TestConfigWarnLevel:
+    def test_warn_maps_to_warning(self):
+        with patch.dict(os.environ, {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "SPOTIFY_CLIENT_ID": "s",
+            "SPOTIFY_CLIENT_SECRET": "ss",
+            "SLSKD_HOST": "h",
+            "SLSKD_API_KEY": "k",
+            "LOG_LEVEL": "WARN",
+        }, clear=False):
+            config = Config()
+            assert config.log_level == logging.WARNING
+
+
+class TestConfigParseIdSet:
+    def test_empty_string(self):
+        assert Config._parse_id_set("") == set()
+
+    def test_whitespace_only(self):
+        assert Config._parse_id_set("   ") == set()
+
+    def test_single_id(self):
+        assert Config._parse_id_set("123") == {123}
+
+    def test_multiple_ids(self):
+        assert Config._parse_id_set("1,2,3") == {1, 2, 3}
+
+    def test_with_spaces(self):
+        assert Config._parse_id_set(" 1 , 2 , 3 ") == {1, 2, 3}
+
+    def test_trailing_comma(self):
+        assert Config._parse_id_set("1,2,") == {1, 2}

--- a/tests/test_config_extended.py
+++ b/tests/test_config_extended.py
@@ -9,14 +9,18 @@ from music_downloader.config import Config, setup_logging
 
 class TestSetupLogging:
     def test_configures_logging(self):
-        with patch.dict(os.environ, {
-            "TELEGRAM_BOT_TOKEN": "t",
-            "SPOTIFY_CLIENT_ID": "s",
-            "SPOTIFY_CLIENT_SECRET": "ss",
-            "SLSKD_HOST": "h",
-            "SLSKD_API_KEY": "k",
-            "LOG_LEVEL": "DEBUG",
-        }, clear=False):
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_BOT_TOKEN": "t",
+                "SPOTIFY_CLIENT_ID": "s",
+                "SPOTIFY_CLIENT_SECRET": "ss",
+                "SLSKD_HOST": "h",
+                "SLSKD_API_KEY": "k",
+                "LOG_LEVEL": "DEBUG",
+            },
+            clear=False,
+        ):
             config = Config()
             setup_logging(config)
             assert logging.getLogger("httpx").level == logging.WARNING
@@ -27,14 +31,18 @@ class TestSetupLogging:
 
 class TestConfigWarnLevel:
     def test_warn_maps_to_warning(self):
-        with patch.dict(os.environ, {
-            "TELEGRAM_BOT_TOKEN": "t",
-            "SPOTIFY_CLIENT_ID": "s",
-            "SPOTIFY_CLIENT_SECRET": "ss",
-            "SLSKD_HOST": "h",
-            "SLSKD_API_KEY": "k",
-            "LOG_LEVEL": "WARN",
-        }, clear=False):
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_BOT_TOKEN": "t",
+                "SPOTIFY_CLIENT_ID": "s",
+                "SPOTIFY_CLIENT_SECRET": "ss",
+                "SLSKD_HOST": "h",
+                "SLSKD_API_KEY": "k",
+                "LOG_LEVEL": "WARN",
+            },
+            clear=False,
+        ):
             config = Config()
             assert config.log_level == logging.WARNING
 

--- a/tests/test_embed_artwork.py
+++ b/tests/test_embed_artwork.py
@@ -13,11 +13,24 @@ def _create_test_flac(path: str, with_art: bool = False) -> None:
     """Create a minimal valid FLAC file."""
     streaminfo = bytes(
         [
-            0x10, 0x00, 0x10, 0x00,
-            0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00,
-            0x0A, 0xC4, 0x42, 0xF0,
-            0x00, 0x00, 0x00, 0x00,
+            0x10,
+            0x00,
+            0x10,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x0A,
+            0xC4,
+            0x42,
+            0xF0,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
         ]
         + [0x00] * 16
     )
@@ -44,15 +57,7 @@ class TestFetchSpotifyArtwork:
     def test_returns_bytes_on_success(self):
         mock_sp = MagicMock()
         mock_sp.search.return_value = {
-            "tracks": {
-                "items": [
-                    {
-                        "album": {
-                            "images": [{"url": "https://example.com/art.jpg"}]
-                        }
-                    }
-                ]
-            }
+            "tracks": {"items": [{"album": {"images": [{"url": "https://example.com/art.jpg"}]}}]}
         }
         with patch("music_downloader.tools.embed_artwork.httpx") as mock_httpx:
             mock_resp = MagicMock()
@@ -70,9 +75,7 @@ class TestFetchSpotifyArtwork:
 
     def test_returns_none_no_images(self):
         mock_sp = MagicMock()
-        mock_sp.search.return_value = {
-            "tracks": {"items": [{"album": {"images": []}}]}
-        }
+        mock_sp.search.return_value = {"tracks": {"items": [{"album": {"images": []}}]}}
         result = fetch_spotify_artwork(mock_sp, "Artist", "Title")
         assert result is None
 

--- a/tests/test_embed_artwork.py
+++ b/tests/test_embed_artwork.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import mutagen.flac
 import mutagen.mp4
-import pytest
 
 from music_downloader.tools.embed_artwork import embed_artwork_into_file, fetch_spotify_artwork
 

--- a/tests/test_embed_artwork.py
+++ b/tests/test_embed_artwork.py
@@ -1,0 +1,148 @@
+"""Tests for embed_artwork module."""
+
+import struct
+from unittest.mock import MagicMock, patch
+
+import mutagen.flac
+import mutagen.mp4
+import pytest
+
+from music_downloader.tools.embed_artwork import embed_artwork_into_file, fetch_spotify_artwork
+
+
+def _create_test_flac(path: str, with_art: bool = False) -> None:
+    """Create a minimal valid FLAC file."""
+    streaminfo = bytes(
+        [
+            0x10, 0x00, 0x10, 0x00,
+            0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00,
+            0x0A, 0xC4, 0x42, 0xF0,
+            0x00, 0x00, 0x00, 0x00,
+        ]
+        + [0x00] * 16
+    )
+    streaminfo_header = struct.pack(">I", (0x00 << 24) | 34)
+    padding_header = struct.pack(">I", (0x81 << 24) | 0)
+    with open(path, "wb") as f:
+        f.write(b"fLaC")
+        f.write(streaminfo_header)
+        f.write(streaminfo)
+        f.write(padding_header)
+
+    if with_art:
+        audio = mutagen.flac.FLAC(path)
+        pic = mutagen.flac.Picture()
+        pic.type = 3
+        pic.mime = "image/jpeg"
+        pic.desc = "Cover"
+        pic.data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        audio.add_picture(pic)
+        audio.save()
+
+
+class TestFetchSpotifyArtwork:
+    def test_returns_bytes_on_success(self):
+        mock_sp = MagicMock()
+        mock_sp.search.return_value = {
+            "tracks": {
+                "items": [
+                    {
+                        "album": {
+                            "images": [{"url": "https://example.com/art.jpg"}]
+                        }
+                    }
+                ]
+            }
+        }
+        with patch("music_downloader.tools.embed_artwork.httpx") as mock_httpx:
+            mock_resp = MagicMock()
+            mock_resp.content = b"\xff\xd8\xff\xe0JFIF"
+            mock_resp.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_resp
+            result = fetch_spotify_artwork(mock_sp, "Artist", "Title")
+            assert result == b"\xff\xd8\xff\xe0JFIF"
+
+    def test_returns_none_no_tracks(self):
+        mock_sp = MagicMock()
+        mock_sp.search.return_value = {"tracks": {"items": []}}
+        result = fetch_spotify_artwork(mock_sp, "Artist", "Title")
+        assert result is None
+
+    def test_returns_none_no_images(self):
+        mock_sp = MagicMock()
+        mock_sp.search.return_value = {
+            "tracks": {"items": [{"album": {"images": []}}]}
+        }
+        result = fetch_spotify_artwork(mock_sp, "Artist", "Title")
+        assert result is None
+
+    def test_returns_none_on_exception(self):
+        mock_sp = MagicMock()
+        mock_sp.search.side_effect = Exception("API error")
+        result = fetch_spotify_artwork(mock_sp, "Artist", "Title")
+        assert result is None
+
+
+class TestEmbedArtworkIntoFile:
+    def test_embed_into_flac(self, tmp_path):
+        flac_path = str(tmp_path / "test.flac")
+        _create_test_flac(flac_path)
+        image_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        result = embed_artwork_into_file(flac_path, image_data)
+        assert result is True
+        audio = mutagen.flac.FLAC(flac_path)
+        assert len(audio.pictures) == 1
+
+    def test_skip_flac_with_existing_art(self, tmp_path):
+        flac_path = str(tmp_path / "test.flac")
+        _create_test_flac(flac_path, with_art=True)
+        image_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        result = embed_artwork_into_file(flac_path, image_data)
+        assert result is False
+
+    def test_unsupported_format(self, tmp_path):
+        txt_path = str(tmp_path / "test.txt")
+        with open(txt_path, "w") as f:
+            f.write("not audio")
+        result = embed_artwork_into_file(txt_path, b"\x00")
+        assert result is False
+
+    def test_embed_into_m4a(self, tmp_path):
+        """Test embedding into M4A (mocked since creating valid M4A is complex)."""
+        m4a_path = str(tmp_path / "test.m4a")
+        with open(m4a_path, "wb") as f:
+            f.write(b"\x00" * 100)
+
+        with patch("music_downloader.tools.embed_artwork.mutagen.mp4.MP4") as mock_mp4:
+            mock_file = MagicMock()
+            mock_file.tags = {}
+            mock_mp4.return_value = mock_file
+            result = embed_artwork_into_file(m4a_path, b"\xff\xd8\xff\xe0")
+            assert result is True
+
+    def test_embed_m4a_with_existing_art(self, tmp_path):
+        m4a_path = str(tmp_path / "test.m4a")
+        with open(m4a_path, "wb") as f:
+            f.write(b"\x00" * 100)
+
+        with patch("music_downloader.tools.embed_artwork.mutagen.mp4.MP4") as mock_mp4:
+            mock_file = MagicMock()
+            tags_mock = MagicMock()
+            tags_mock.get.return_value = [b"existing"]
+            tags_mock.__bool__ = lambda self: True
+            mock_file.tags = tags_mock
+            mock_mp4.return_value = mock_file
+            result = embed_artwork_into_file(m4a_path, b"\xff\xd8\xff\xe0")
+            assert result is False
+
+    def test_exception_returns_false(self, tmp_path):
+        result = embed_artwork_into_file("/nonexistent/path.flac", b"\x00")
+        assert result is False
+
+    def test_no_extension(self, tmp_path):
+        path = str(tmp_path / "noext")
+        with open(path, "w") as f:
+            f.write("data")
+        result = embed_artwork_into_file(path, b"\x00")
+        assert result is False

--- a/tests/test_file_handler_extended.py
+++ b/tests/test_file_handler_extended.py
@@ -1,6 +1,5 @@
 """Extended tests for file_handler - covering find_similar and edge cases."""
 
-import os
 
 import pytest
 

--- a/tests/test_file_handler_extended.py
+++ b/tests/test_file_handler_extended.py
@@ -1,0 +1,150 @@
+"""Extended tests for file_handler - covering find_similar and edge cases."""
+
+import os
+
+import pytest
+
+from music_downloader.processor.file_handler import FileProcessor
+
+
+class TestFindSimilar:
+    @pytest.fixture
+    def processor(self, tmp_path):
+        download_dir = tmp_path / "downloads"
+        output_dir = tmp_path / "output"
+        download_dir.mkdir()
+        output_dir.mkdir()
+        return FileProcessor(str(download_dir), str(output_dir))
+
+    def test_no_output_dir(self, tmp_path):
+        p = FileProcessor(str(tmp_path / "dl"), str(tmp_path / "nonexistent"))
+        result = p.find_similar("test")
+        assert result == []
+
+    def test_finds_similar_files(self, processor, tmp_path):
+        output_dir = tmp_path / "output"
+        (output_dir / "Nancy Sinatra - Bang Bang.flac").write_text("data")
+        (output_dir / "Nancy Sinatra - Summer Wine.flac").write_text("data")
+        result = processor.find_similar("Nancy Sinatra Bang Bang")
+        assert len(result) > 0
+        assert "Nancy Sinatra - Bang Bang.flac" in result
+
+    def test_no_similar_files(self, processor, tmp_path):
+        output_dir = tmp_path / "output"
+        (output_dir / "Completely Different.flac").write_text("data")
+        result = processor.find_similar("Nancy Sinatra Bang Bang")
+        assert result == []
+
+    def test_ignores_non_audio(self, processor, tmp_path):
+        output_dir = tmp_path / "output"
+        (output_dir / "Nancy Sinatra - Bang Bang.txt").write_text("data")
+        (output_dir / "Nancy Sinatra - Bang Bang.jpg").write_text("data")
+        result = processor.find_similar("Nancy Sinatra Bang Bang")
+        assert result == []
+
+    def test_sorted_by_similarity(self, processor, tmp_path):
+        output_dir = tmp_path / "output"
+        (output_dir / "Nancy Sinatra - Bang Bang.flac").write_text("data")
+        (output_dir / "Nancy Sinatra - Something Else.flac").write_text("data")
+        result = processor.find_similar("Nancy Sinatra Bang Bang")
+        if len(result) >= 2:
+            # Best match should be first
+            assert "Bang Bang" in result[0]
+
+    def test_various_audio_extensions(self, processor, tmp_path):
+        output_dir = tmp_path / "output"
+        (output_dir / "Song.mp3").write_text("data")
+        (output_dir / "Song.ogg").write_text("data")
+        (output_dir / "Song.wav").write_text("data")
+        result = processor.find_similar("Song")
+        assert len(result) == 3
+
+    def test_empty_query(self, processor, tmp_path):
+        output_dir = tmp_path / "output"
+        (output_dir / "Song.flac").write_text("data")
+        result = processor.find_similar("")
+        # Empty query should not match well (low similarity)
+        # but should not crash
+        assert isinstance(result, list)
+
+    def test_custom_threshold(self, processor, tmp_path):
+        output_dir = tmp_path / "output"
+        (output_dir / "Nancy Sinatra - Bang Bang.flac").write_text("data")
+        # High threshold should be stricter
+        result_high = processor.find_similar("Nancy Sinatra Bang Bang", threshold=0.9)
+        result_low = processor.find_similar("Nancy Sinatra Bang Bang", threshold=0.3)
+        assert len(result_low) >= len(result_high)
+
+
+class TestFindDownloadedFileFallback:
+    def test_fallback_search(self, tmp_path):
+        download_dir = tmp_path / "downloads"
+        output_dir = tmp_path / "output"
+        download_dir.mkdir()
+        output_dir.mkdir()
+        # File under a different username directory
+        other_dir = download_dir / "otheruser" / "subdir"
+        other_dir.mkdir(parents=True)
+        (other_dir / "song.flac").write_text("data")
+
+        processor = FileProcessor(str(download_dir), str(output_dir))
+        # Search with wrong username should still find via fallback
+        result = processor.find_downloaded_file("wronguser", "\\Music\\song.flac")
+        assert result is not None
+        assert result.endswith("song.flac")
+
+
+class TestProcessFileEdgeCases:
+    def test_process_nonexistent_file(self, tmp_path):
+        download_dir = tmp_path / "downloads"
+        output_dir = tmp_path / "output"
+        download_dir.mkdir()
+        output_dir.mkdir()
+        processor = FileProcessor(str(download_dir), str(output_dir))
+        result = processor.process_file("/nonexistent/file.flac", "Artist", "Title")
+        assert result is None
+
+    def test_process_file_no_extension(self, tmp_path):
+        download_dir = tmp_path / "downloads"
+        output_dir = tmp_path / "output"
+        download_dir.mkdir()
+        output_dir.mkdir()
+        source = tmp_path / "sourcefile"
+        source.write_text("data")
+        processor = FileProcessor(str(download_dir), str(output_dir))
+        result = processor.process_file(str(source), "Artist", "Title")
+        assert result is not None
+
+
+class TestCleanupDownload:
+    def test_cleanup_removes_empty_parent(self, tmp_path):
+        download_dir = tmp_path / "downloads"
+        output_dir = tmp_path / "output"
+        download_dir.mkdir()
+        output_dir.mkdir()
+        parent = tmp_path / "downloads" / "user" / "subdir"
+        parent.mkdir(parents=True)
+        source = parent / "song.flac"
+        source.write_text("data")
+        processor = FileProcessor(str(download_dir), str(output_dir))
+        processor.cleanup_download(str(source))
+        assert not source.exists()
+        assert not parent.exists()
+
+    def test_cleanup_nonexistent(self, tmp_path):
+        download_dir = tmp_path / "downloads"
+        output_dir = tmp_path / "output"
+        download_dir.mkdir()
+        output_dir.mkdir()
+        processor = FileProcessor(str(download_dir), str(output_dir))
+        result = processor.cleanup_download("/nonexistent/file.flac")
+        assert result is False
+
+    def test_build_filename_custom_template(self, tmp_path):
+        download_dir = tmp_path / "downloads"
+        output_dir = tmp_path / "output"
+        download_dir.mkdir()
+        output_dir.mkdir()
+        processor = FileProcessor(str(download_dir), str(output_dir), filename_template="{title} by {artist}")
+        result = processor.build_filename("Artist", "Song", "mp3")
+        assert result == "Song by Artist.mp3"

--- a/tests/test_file_handler_extended.py
+++ b/tests/test_file_handler_extended.py
@@ -1,6 +1,5 @@
 """Extended tests for file_handler - covering find_similar and edge cases."""
 
-
 import pytest
 
 from music_downloader.processor.file_handler import FileProcessor

--- a/tests/test_handlers_comprehensive.py
+++ b/tests/test_handlers_comprehensive.py
@@ -324,10 +324,14 @@ class TestMusicBotCancellation:
     def test_cancel_removes_downloads_for_chat(self, mock_slskd, mock_spotify):
         bot = MusicBot(_make_config())
         bot.downloads["1"] = PendingDownload(
-            track=_make_track(), result=_make_search_result(), chat_id=12345,
+            track=_make_track(),
+            result=_make_search_result(),
+            chat_id=12345,
         )
         bot.downloads["2"] = PendingDownload(
-            track=_make_track(), result=_make_search_result(), chat_id=99999,
+            track=_make_track(),
+            result=_make_search_result(),
+            chat_id=99999,
         )
         bot._cancel_chat_operations(12345)
         assert "1" not in bot.downloads
@@ -441,7 +445,9 @@ class TestMusicBotCommands:
     async def test_cmd_status_with_downloads(self, mock_slskd, mock_spotify):
         bot = MusicBot(_make_config())
         bot.downloads["1"] = PendingDownload(
-            track=_make_track(), result=_make_search_result(), chat_id=67890,
+            track=_make_track(),
+            result=_make_search_result(),
+            chat_id=67890,
         )
         update = _make_update()
         context = _make_context()
@@ -687,7 +693,9 @@ class TestMusicBotCallbackHandler:
         track = _make_track()
         result = _make_search_result()
         bot.downloads["1"] = PendingDownload(
-            track=track, result=result, chat_id=67890,
+            track=track,
+            result=result,
+            chat_id=67890,
             source_path="/downloads/song.flac",
         )
         update = _make_callback_update(data="approve:1")
@@ -706,7 +714,9 @@ class TestMusicBotCallbackHandler:
         track = _make_track()
         result = _make_search_result()
         bot.downloads["1"] = PendingDownload(
-            track=track, result=result, chat_id=67890,
+            track=track,
+            result=result,
+            chat_id=67890,
             source_path="/downloads/song.flac",
         )
         update = _make_callback_update(data="approve:1")
@@ -721,7 +731,9 @@ class TestMusicBotCallbackHandler:
         track = _make_track()
         result = _make_search_result()
         bot.downloads["1"] = PendingDownload(
-            track=track, result=result, chat_id=67890,
+            track=track,
+            result=result,
+            chat_id=67890,
             source_path=None,
         )
         update = _make_callback_update(data="approve:1")
@@ -736,7 +748,9 @@ class TestMusicBotCallbackHandler:
         track = _make_track()
         result = _make_search_result()
         bot.downloads["1"] = PendingDownload(
-            track=track, result=result, chat_id=67890,
+            track=track,
+            result=result,
+            chat_id=67890,
         )
         update = _make_callback_update(data="reject:1")
         context = _make_context()
@@ -975,7 +989,9 @@ class TestMusicBotDoSearch:
         """When query has 'Artist - Title', filter by artist."""
         bot = MusicBot(_make_config())
         t1 = _make_track()
-        t2 = TrackInfo(artist="Other Artist", title="Bang Bang", album="X", duration_ms=162000, spotify_url="", year="2024")
+        t2 = TrackInfo(
+            artist="Other Artist", title="Bang Bang", album="X", duration_ms=162000, spotify_url="", year="2024"
+        )
         bot.spotify = MagicMock()
         bot.spotify.search_multiple = MagicMock(return_value=[t1, t2])
         bot._do_slskd_search = AsyncMock()
@@ -998,7 +1014,9 @@ class TestMusicBotDismissOtherDownloads:
         bot = MusicBot(_make_config())
         bot.pending[67890] = PendingSearch(query="test", track=_make_track(), message_id=100)
         bot.downloads["2"] = PendingDownload(
-            track=_make_track(), result=_make_search_result(), chat_id=67890,
+            track=_make_track(),
+            result=_make_search_result(),
+            chat_id=67890,
             approval_message_id=200,
         )
         context = _make_context()

--- a/tests/test_handlers_comprehensive.py
+++ b/tests/test_handlers_comprehensive.py
@@ -1,0 +1,1028 @@
+"""Comprehensive tests for bot handlers - MusicBot class and helper functions."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_downloader.bot.handlers import (
+    MusicBot,
+    PendingDownload,
+    PendingSearch,
+    _build_reduced_queries,
+    _clean_search_title,
+    _escape_md,
+    _extract_latin_keywords,
+    _has_non_latin_script,
+    _safe_edit,
+)
+from music_downloader.metadata.spotify import TrackInfo
+from music_downloader.search.slskd_client import SearchResult
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+import tempfile
+
+_tmp_dir = None
+
+
+def _get_tmp_dir():
+    global _tmp_dir
+    if _tmp_dir is None:
+        _tmp_dir = tempfile.mkdtemp()
+    return _tmp_dir
+
+
+def _make_config():
+    """Create a mock Config object."""
+    td = _get_tmp_dir()
+    config = MagicMock()
+    config.telegram_bot_token = "test-token"
+    config.spotify_client_id = "test-id"
+    config.spotify_client_secret = "test-secret"
+    config.slskd_host = "http://localhost:5030"
+    config.slskd_api_key = "test-key"
+    config.telegram_allowed_users = set()
+    config.auto_mode = False
+    config.max_results = 5
+    config.duration_tolerance_secs = 5
+    config.exclude_keywords = ["live", "remix"]
+    config.download_dir = os.path.join(td, "downloads")
+    config.output_dir = os.path.join(td, "music")
+    config.filename_template = "{artist} - {title}"
+    config.search_timeout_secs = 30
+    config.download_timeout_secs = 600
+    return config
+
+
+def _make_track():
+    return TrackInfo(
+        artist="Nancy Sinatra",
+        title="Bang Bang",
+        album="How Does That Grab You?",
+        duration_ms=162_000,
+        spotify_url="https://open.spotify.com/track/xxx",
+        year="1966",
+    )
+
+
+def _make_search_result(idx=0):
+    return SearchResult(
+        username=f"user{idx}",
+        filename=f"\\Music\\Nancy Sinatra - Bang Bang {idx}.flac",
+        size=30_000_000,
+        bit_rate=900,
+        bit_depth=16,
+        sample_rate=44100,
+        length=162,
+        has_free_slot=True,
+        upload_speed=1_000_000,
+        queue_length=0,
+    )
+
+
+def _make_update(user_id=12345, chat_id=67890, text="Nancy Sinatra Bang Bang"):
+    """Create a mock Telegram Update object."""
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_chat.id = chat_id
+    update.message = AsyncMock()
+    update.message.text = text
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+def _make_callback_update(user_id=12345, chat_id=67890, data="dl:0"):
+    """Create a mock callback query Update."""
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_chat.id = chat_id
+    update.callback_query = AsyncMock()
+    update.callback_query.from_user.id = user_id
+    update.callback_query.data = data
+    update.callback_query.answer = AsyncMock()
+    update.callback_query.edit_message_text = AsyncMock()
+    update.callback_query.edit_message_caption = AsyncMock()
+    return update
+
+
+def _make_context(chat_id=67890):
+    """Create a mock context."""
+    context = MagicMock()
+    context.bot = AsyncMock()
+    context.bot.send_message = AsyncMock()
+    context.bot.send_audio = AsyncMock()
+    context.bot.send_document = AsyncMock()
+    context.bot.edit_message_reply_markup = AsyncMock()
+    context.bot.edit_message_caption = AsyncMock()
+    context.bot.edit_message_text = AsyncMock()
+    context.application = MagicMock()
+    context.application.create_task = MagicMock(side_effect=lambda coro, **kw: asyncio.ensure_future(coro))
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeMd:
+    def test_escapes_special_chars(self):
+        assert _escape_md("hello_world") == "hello\\_world"
+        assert _escape_md("*bold*") == "\\*bold\\*"
+        assert _escape_md("[link](url)") == "\\[link\\]\\(url\\)"
+
+    def test_plain_text_unchanged(self):
+        assert _escape_md("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert _escape_md("") == ""
+
+
+class TestSafeEdit:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        result = await _safe_edit(msg, "new text")
+        assert result is True
+        msg.edit_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bad_request(self):
+        from telegram.error import BadRequest
+
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock(side_effect=BadRequest("Message not modified"))
+        result = await _safe_edit(msg, "text")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_timed_out(self):
+        from telegram.error import TimedOut
+
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock(side_effect=TimedOut())
+        result = await _safe_edit(msg, "text")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_network_error(self):
+        from telegram.error import NetworkError
+
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock(side_effect=NetworkError("connection failed"))
+        result = await _safe_edit(msg, "text")
+        assert result is False
+
+
+class TestHasNonLatinScript:
+    def test_latin_only(self):
+        assert _has_non_latin_script("Hello World") is False
+
+    def test_cjk(self):
+        assert _has_non_latin_script("紅") is True
+
+    def test_cyrillic(self):
+        assert _has_non_latin_script("Привет") is True
+
+    def test_mixed(self):
+        assert _has_non_latin_script("紅 - KURENAI") is True
+
+    def test_empty(self):
+        assert _has_non_latin_script("") is False
+
+    def test_numbers_only(self):
+        assert _has_non_latin_script("12345") is False
+
+
+class TestExtractLatinKeywords:
+    def test_mixed_script(self):
+        result = _extract_latin_keywords("紅 - KURENAI - Single Long Version")
+        assert "KURENAI" in result
+        # Noise words should be filtered
+        assert "Single" not in result
+        assert "Long" not in result
+        assert "Version" not in result
+
+    def test_all_noise(self):
+        result = _extract_latin_keywords("The Single Version Mix")
+        assert result == []
+
+    def test_pure_latin(self):
+        result = _extract_latin_keywords("Purple Rain")
+        assert "Purple" in result
+        assert "Rain" in result
+
+    def test_short_words_filtered(self):
+        result = _extract_latin_keywords("I Am A Star")
+        # Single-char words filtered by {2,} regex
+        assert "Star" in result
+
+
+class TestCleanSearchTitleExtended:
+    def test_deluxe_edition(self):
+        assert _clean_search_title("Song - Deluxe Edition") == "Song"
+
+    def test_anniversary_edition(self):
+        assert _clean_search_title("Song - Anniversary Edition") == "Song"
+
+    def test_super_deluxe(self):
+        assert _clean_search_title("Song - Super Deluxe") == "Song"
+
+    def test_paren_mono(self):
+        assert _clean_search_title("Song (Mono)") == "Song"
+
+    def test_paren_stereo(self):
+        assert _clean_search_title("Song (Stereo)") == "Song"
+
+    def test_year_mix(self):
+        assert _clean_search_title("Song (2009 Mix)") == "Song"
+
+
+# ---------------------------------------------------------------------------
+# MusicBot tests
+# ---------------------------------------------------------------------------
+
+
+class TestMusicBotInit:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_init(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        bot = MusicBot(config)
+        assert bot.auto_mode is False
+        assert bot.pending == {}
+        assert bot.downloads == {}
+        assert bot.history == []
+
+
+class TestMusicBotAuthorization:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_is_authorized_no_restrictions(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.telegram_allowed_users = set()
+        bot = MusicBot(config)
+        assert bot._is_authorized(99999) is True
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_is_authorized_allowed(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.telegram_allowed_users = {12345, 67890}
+        bot = MusicBot(config)
+        assert bot._is_authorized(12345) is True
+        assert bot._is_authorized(99999) is False
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_check_auth_denied(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.telegram_allowed_users = {11111}
+        bot = MusicBot(config)
+        update = _make_update(user_id=99999)
+        result = await bot._check_auth(update)
+        assert result is False
+        update.message.reply_text.assert_called_once_with("You are not authorized to use this bot.")
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_check_auth_allowed(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.telegram_allowed_users = set()
+        bot = MusicBot(config)
+        update = _make_update()
+        result = await bot._check_auth(update)
+        assert result is True
+
+
+class TestMusicBotCancellation:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_cancel_chat_operations_empty(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        had_work = bot._cancel_chat_operations(12345)
+        assert had_work is False
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_cancel_chat_operations_with_pending(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.pending[12345] = PendingSearch(query="test")
+        had_work = bot._cancel_chat_operations(12345)
+        assert had_work is True
+        assert 12345 not in bot.pending
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_cancel_removes_downloads_for_chat(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.downloads["1"] = PendingDownload(
+            track=_make_track(), result=_make_search_result(), chat_id=12345,
+        )
+        bot.downloads["2"] = PendingDownload(
+            track=_make_track(), result=_make_search_result(), chat_id=99999,
+        )
+        bot._cancel_chat_operations(12345)
+        assert "1" not in bot.downloads
+        assert "2" in bot.downloads
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_is_stale(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot._chat_generation[123] = 5
+        assert bot._is_stale(123, 5) is False
+        assert bot._is_stale(123, 4) is True
+        assert bot._is_stale(123, 6) is True
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_track_task(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        loop = asyncio.new_event_loop()
+        task = loop.create_future()
+        task.set_result(None)
+        bot._track_task(123, task)
+        assert task in bot._active_tasks.get(123, set())
+        loop.close()
+
+
+class TestMusicBotCommands:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_start(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_start(update, context)
+        update.message.reply_text.assert_called_once()
+        call_args = update.message.reply_text.call_args
+        assert "Send me a song name" in call_args[0][0]
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_start_unauthorized(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.telegram_allowed_users = {11111}
+        bot = MusicBot(config)
+        update = _make_update(user_id=99999)
+        context = _make_context()
+        await bot.cmd_start(update, context)
+        update.message.reply_text.assert_called_once_with("You are not authorized to use this bot.")
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_help(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_help(update, context)
+        update.message.reply_text.assert_called()
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_auto(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_auto(update, context)
+        call_args = update.message.reply_text.call_args
+        assert "OFF" in call_args[0][0]
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_auto_on(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.auto_mode = True
+        bot = MusicBot(config)
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_auto(update, context)
+        call_args = update.message.reply_text.call_args
+        assert "ON" in call_args[0][0]
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_status_empty(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_status(update, context)
+        update.message.reply_text.assert_called_once_with("No active searches or downloads.")
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_status_with_pending(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.pending[67890] = PendingSearch(query="test", track=_make_track())
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_status(update, context)
+        call_args = update.message.reply_text.call_args
+        assert "Nancy Sinatra" in call_args[0][0]
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_status_with_downloads(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.downloads["1"] = PendingDownload(
+            track=_make_track(), result=_make_search_result(), chat_id=67890,
+        )
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_status(update, context)
+        call_args = update.message.reply_text.call_args
+        assert "Active downloads" in call_args[0][0]
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_history_empty(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_history(update, context)
+        update.message.reply_text.assert_called_once_with("No downloads yet.")
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_cmd_history_with_entries(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.history = [
+            {"filename": "Artist - Song.flac", "status": "success"},
+            {"filename": "Artist - Song2.flac", "status": "rejected"},
+            {"filename": "Artist - Song3.flac", "status": "failed"},
+        ]
+        update = _make_update()
+        context = _make_context()
+        await bot.cmd_history(update, context)
+        call_args = update.message.reply_text.call_args
+        text = call_args[0][0]
+        assert "Recent downloads" in text
+
+
+class TestMusicBotCallbackHandler:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_auto_toggle_on(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_callback_update(data="auto:on")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert bot.auto_mode is True
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_auto_toggle_off(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.auto_mode = True
+        bot = MusicBot(config)
+        update = _make_callback_update(data="auto:off")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert bot.auto_mode is False
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_duplicate_cancel(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.pending[67890] = PendingSearch(query="test")
+        update = _make_callback_update(data="dup:cancel")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert 67890 not in bot.pending
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_duplicate_continue(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.pending[67890] = PendingSearch(query="test song")
+        update = _make_callback_update(data="dup:continue")
+        context = _make_context()
+        # Mock _do_search to prevent actual execution
+        bot._do_search = AsyncMock()
+        await bot.handle_callback(update, context)
+        bot._do_search.assert_called_once()
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_spotify_cancel(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot._spotify_candidates[67890] = [_make_track()]
+        update = _make_callback_update(data="sp:cancel")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert 67890 not in bot._spotify_candidates
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_spotify_select(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot._spotify_candidates[67890] = [_make_track(), _make_track()]
+        update = _make_callback_update(data="sp:0")
+        context = _make_context()
+        bot._do_slskd_search = AsyncMock()
+        await bot.handle_callback(update, context)
+        bot._do_slskd_search.assert_called_once()
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_spotify_select_invalid_index(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot._spotify_candidates[67890] = [_make_track()]
+        update = _make_callback_update(data="sp:99")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_spotify_page(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot._spotify_candidates[67890] = [_make_track() for _ in range(12)]
+        bot._spotify_page[67890] = 0
+        update = _make_callback_update(data="sp_page:1")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert bot._spotify_page[67890] == 1
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_spotify_page_expired(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_callback_update(data="sp_page:0")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        update.callback_query.edit_message_text.assert_called_with("Search expired. Send a new query.")
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_spotify_page_invalid(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot._spotify_candidates[67890] = [_make_track()]
+        update = _make_callback_update(data="sp_page:abc")
+        context = _make_context()
+        # Should not raise
+        await bot.handle_callback(update, context)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_download_cancel(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.pending[67890] = PendingSearch(query="test", track=_make_track(), results=[_make_search_result()])
+        update = _make_callback_update(data="dl:cancel")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert 67890 not in bot.pending
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_download_select(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        result = _make_search_result()
+        bot.pending[67890] = PendingSearch(query="test", track=track, results=[result])
+        update = _make_callback_update(data="dl:0")
+        context = _make_context()
+        # Mock the download to prevent actual execution
+        bot._do_download = AsyncMock()
+        context.application.create_task = MagicMock(return_value=MagicMock())
+        await bot.handle_callback(update, context)
+        context.application.create_task.assert_called_once()
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_download_auto_pick(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        result = _make_search_result()
+        bot.pending[67890] = PendingSearch(query="test", track=track, results=[result])
+        update = _make_callback_update(data="dl:auto")
+        context = _make_context()
+        bot._do_download = AsyncMock()
+        context.application.create_task = MagicMock(return_value=MagicMock())
+        await bot.handle_callback(update, context)
+        context.application.create_task.assert_called_once()
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_download_select_expired(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_callback_update(data="dl:0")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        update.callback_query.edit_message_text.assert_called_with("Search expired. Send a new query.")
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_download_select_invalid_index(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.pending[67890] = PendingSearch(query="test", track=_make_track(), results=[_make_search_result()])
+        update = _make_callback_update(data="dl:99")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_results_page(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        results = [_make_search_result(i) for i in range(15)]
+        bot.pending[67890] = PendingSearch(query="test", track=track, results=results)
+        update = _make_callback_update(data="dl_page:1")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert bot.pending[67890].page == 1
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_results_page_expired(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_callback_update(data="dl_page:0")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        update.callback_query.edit_message_text.assert_called_with("Search expired. Send a new query.")
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_approve_download(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.processor = MagicMock()
+        bot.processor.process_file = MagicMock(return_value="/music/Artist - Song.flac")
+        bot._embed_spotify_artwork = AsyncMock()
+        bot._dismiss_other_downloads = AsyncMock()
+        track = _make_track()
+        result = _make_search_result()
+        bot.downloads["1"] = PendingDownload(
+            track=track, result=result, chat_id=67890,
+            source_path="/downloads/song.flac",
+        )
+        update = _make_callback_update(data="approve:1")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert "1" not in bot.downloads
+        assert len(bot.history) == 1
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_approve_process_fails(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.processor = MagicMock()
+        bot.processor.process_file = MagicMock(return_value=None)
+        track = _make_track()
+        result = _make_search_result()
+        bot.downloads["1"] = PendingDownload(
+            track=track, result=result, chat_id=67890,
+            source_path="/downloads/song.flac",
+        )
+        update = _make_callback_update(data="approve:1")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_approve_no_source_path(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        result = _make_search_result()
+        bot.downloads["1"] = PendingDownload(
+            track=track, result=result, chat_id=67890,
+            source_path=None,
+        )
+        update = _make_callback_update(data="approve:1")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_reject_download(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        result = _make_search_result()
+        bot.downloads["1"] = PendingDownload(
+            track=track, result=result, chat_id=67890,
+        )
+        update = _make_callback_update(data="reject:1")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        assert "1" not in bot.downloads
+        assert len(bot.history) == 1
+        assert bot.history[0]["status"] == "rejected"
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_approve_expired(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_callback_update(data="approve:999")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_unauthorized_callback(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.telegram_allowed_users = {11111}
+        bot = MusicBot(config)
+        update = _make_callback_update(user_id=99999, data="auto:on")
+        context = _make_context()
+        await bot.handle_callback(update, context)
+        # Should not change auto_mode
+        assert bot.auto_mode is False
+
+
+class TestMusicBotHelpers:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_format_results(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        results = [_make_search_result(i) for i in range(3)]
+        text = bot._format_results(track, results)
+        assert "Nancy Sinatra" in text
+        assert "Bang Bang" in text
+        assert "#1" in text
+        assert "#3" in text
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_format_results_fallback(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        results = [_make_search_result()]
+        text = bot._format_results(track, results, is_fallback=True)
+        assert "No FLAC found" in text
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_format_results_pagination(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        results = [_make_search_result(i) for i in range(15)]
+        text = bot._format_results(track, results, page=0, page_size=5)
+        assert "Page 1/" in text
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_format_spotify_results(self, mock_slskd, mock_spotify):
+        tracks = [_make_track() for _ in range(3)]
+        text = MusicBot._format_spotify_results(tracks)
+        assert "Multiple matches" in text
+        assert "Nancy Sinatra" in text
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_format_spotify_results_pagination(self, mock_slskd, mock_spotify):
+        tracks = [_make_track() for _ in range(12)]
+        text = MusicBot._format_spotify_results(tracks, page=0, page_size=5)
+        assert "page 1/" in text
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_add_history(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        result = _make_search_result()
+        bot._add_history(track, result, "success")
+        assert len(bot.history) == 1
+        assert bot.history[0]["status"] == "success"
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_add_history_caps_at_50(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        track = _make_track()
+        result = _make_search_result()
+        for _ in range(55):
+            bot._add_history(track, result, "success")
+        assert len(bot.history) == 50
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    def test_next_dl_id(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        id1 = bot._next_dl_id()
+        id2 = bot._next_dl_id()
+        assert id1 != id2
+        assert id1 == "1"
+        assert id2 == "2"
+
+
+class TestMusicBotHandleText:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_empty_text_ignored(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        update = _make_update(text="   ")
+        context = _make_context()
+        await bot.handle_text(update, context)
+        # Should not proceed to search
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_similar_files_found(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.processor = MagicMock()
+        bot.processor.find_similar = MagicMock(return_value=["Artist - Song.flac"])
+        update = _make_update(text="Artist Song")
+        context = _make_context()
+        await bot.handle_text(update, context)
+        # Should show duplicate warning
+        update.message.reply_text.assert_called_once()
+        call_text = update.message.reply_text.call_args[0][0]
+        assert "Similar files" in call_text
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_unauthorized_text(self, mock_slskd, mock_spotify):
+        config = _make_config()
+        config.telegram_allowed_users = {11111}
+        bot = MusicBot(config)
+        update = _make_update(user_id=99999, text="test")
+        context = _make_context()
+        await bot.handle_text(update, context)
+        update.message.reply_text.assert_called_once_with("You are not authorized to use this bot.")
+
+
+class TestMusicBotDoSearch:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_no_spotify_results(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.spotify = MagicMock()
+        bot.spotify.search_multiple = MagicMock(return_value=[])
+        update = _make_update()
+        context = _make_context()
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        context.bot.send_message = AsyncMock(return_value=msg)
+        bot._chat_generation[67890] = 0
+        await bot._do_search(update, context, "nonexistent song", 0)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_single_spotify_result(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.spotify = MagicMock()
+        bot.spotify.search_multiple = MagicMock(return_value=[_make_track()])
+        bot._do_slskd_search = AsyncMock()
+        update = _make_update()
+        context = _make_context()
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        context.bot.send_message = AsyncMock(return_value=msg)
+        bot._chat_generation[67890] = 0
+        await bot._do_search(update, context, "Nancy Sinatra Bang Bang", 0)
+        bot._do_slskd_search.assert_called_once()
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_multiple_spotify_results(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        tracks = [_make_track(), _make_track()]
+        tracks[1].album = "Different Album"
+        bot.spotify = MagicMock()
+        bot.spotify.search_multiple = MagicMock(return_value=tracks)
+        update = _make_update()
+        context = _make_context()
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        context.bot.send_message = AsyncMock(return_value=msg)
+        bot._chat_generation[67890] = 0
+        await bot._do_search(update, context, "Nancy Sinatra Bang Bang", 0)
+        assert 67890 in bot._spotify_candidates
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_stale_search_aborted(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.spotify = MagicMock()
+        bot.spotify.search_multiple = MagicMock(return_value=[_make_track()])
+        bot._do_slskd_search = AsyncMock()
+        update = _make_update()
+        context = _make_context()
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        context.bot.send_message = AsyncMock(return_value=msg)
+        bot._chat_generation[67890] = 5  # Set generation ahead
+        await bot._do_search(update, context, "test", 0)  # generation 0 is stale
+        bot._do_slskd_search.assert_not_called()
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_exception_handled(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.spotify = MagicMock()
+        bot.spotify.search_multiple = MagicMock(side_effect=Exception("API error"))
+        update = _make_update()
+        context = _make_context()
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        context.bot.send_message = AsyncMock(return_value=msg)
+        bot._chat_generation[67890] = 0
+        await bot._do_search(update, context, "test", 0)
+        # Should not raise
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_artist_filter(self, mock_slskd, mock_spotify):
+        """When query has 'Artist - Title', filter by artist."""
+        bot = MusicBot(_make_config())
+        t1 = _make_track()
+        t2 = TrackInfo(artist="Other Artist", title="Bang Bang", album="X", duration_ms=162000, spotify_url="", year="2024")
+        bot.spotify = MagicMock()
+        bot.spotify.search_multiple = MagicMock(return_value=[t1, t2])
+        bot._do_slskd_search = AsyncMock()
+        update = _make_update()
+        context = _make_context()
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        context.bot.send_message = AsyncMock(return_value=msg)
+        bot._chat_generation[67890] = 0
+        await bot._do_search(update, context, "Nancy Sinatra - Bang Bang", 0)
+        # Should filter to only Nancy Sinatra -> single result -> auto slskd search
+        bot._do_slskd_search.assert_called_once()
+
+
+class TestMusicBotDismissOtherDownloads:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_dismiss(self, mock_slskd, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.pending[67890] = PendingSearch(query="test", track=_make_track(), message_id=100)
+        bot.downloads["2"] = PendingDownload(
+            track=_make_track(), result=_make_search_result(), chat_id=67890,
+            approval_message_id=200,
+        )
+        context = _make_context()
+        await bot._dismiss_other_downloads(context, 67890)
+        assert 67890 not in bot.pending
+        assert "2" not in bot.downloads
+
+
+class TestMusicBotEditApprovalMessage:
+    @pytest.mark.asyncio
+    async def test_edit_caption(self):
+        query = AsyncMock()
+        query.edit_message_caption = AsyncMock()
+        await MusicBot._edit_approval_message(query, "test")
+        query.edit_message_caption.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_text(self):
+        query = AsyncMock()
+        query.edit_message_caption = AsyncMock(side_effect=Exception("no caption"))
+        query.edit_message_text = AsyncMock()
+        await MusicBot._edit_approval_message(query, "test")
+        query.edit_message_text.assert_called_once()

--- a/tests/test_handlers_comprehensive.py
+++ b/tests/test_handlers_comprehensive.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import os
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,7 +17,6 @@ from music_downloader.bot.handlers import (
     MusicBot,
     PendingDownload,
     PendingSearch,
-    _build_reduced_queries,
     _clean_search_title,
     _escape_md,
     _extract_latin_keywords,
@@ -21,14 +25,6 @@ from music_downloader.bot.handlers import (
 )
 from music_downloader.metadata.spotify import TrackInfo
 from music_downloader.search.slskd_client import SearchResult
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-import tempfile
 
 _tmp_dir = None
 

--- a/tests/test_handlers_download.py
+++ b/tests/test_handlers_download.py
@@ -1,0 +1,620 @@
+"""Tests for MusicBot download flow, slskd search, large file handling, and create_bot."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_downloader.bot.handlers import MusicBot, PendingDownload, PendingSearch, create_bot
+from music_downloader.metadata.spotify import TrackInfo
+from music_downloader.processor.flac_analyzer import FlacVerdict
+from music_downloader.search.slskd_client import DownloadStatus, SearchResult
+
+
+_tmp_dir = None
+
+
+def _get_tmp_dir():
+    global _tmp_dir
+    if _tmp_dir is None:
+        _tmp_dir = tempfile.mkdtemp()
+    return _tmp_dir
+
+
+def _make_config():
+    td = _get_tmp_dir()
+    config = MagicMock()
+    config.telegram_bot_token = "test-token"
+    config.spotify_client_id = "test-id"
+    config.spotify_client_secret = "test-secret"
+    config.slskd_host = "http://localhost:5030"
+    config.slskd_api_key = "test-key"
+    config.telegram_allowed_users = set()
+    config.auto_mode = False
+    config.max_results = 5
+    config.duration_tolerance_secs = 5
+    config.exclude_keywords = ["live", "remix"]
+    config.download_dir = os.path.join(td, "downloads2")
+    config.output_dir = os.path.join(td, "music2")
+    config.filename_template = "{artist} - {title}"
+    config.search_timeout_secs = 30
+    config.download_timeout_secs = 600
+    return config
+
+
+def _make_track():
+    return TrackInfo(
+        artist="Nancy Sinatra", title="Bang Bang",
+        album="How Does That Grab You?", duration_ms=162_000,
+        spotify_url="https://open.spotify.com/track/xxx", year="1966",
+    )
+
+
+def _make_result(idx=0, ext="flac"):
+    return SearchResult(
+        username=f"user{idx}",
+        filename=f"\\Music\\Nancy Sinatra - Bang Bang {idx}.{ext}",
+        size=30_000_000, bit_rate=900, bit_depth=16, sample_rate=44100,
+        length=162, has_free_slot=True, upload_speed=1_000_000, queue_length=0,
+    )
+
+
+def _make_context():
+    context = MagicMock()
+    context.bot = AsyncMock()
+    context.bot.send_message = AsyncMock()
+    context.bot.send_audio = AsyncMock()
+    context.bot.send_document = AsyncMock()
+    context.bot.edit_message_reply_markup = AsyncMock()
+    context.bot.edit_message_caption = AsyncMock()
+    context.bot.edit_message_text = AsyncMock()
+    context.application = MagicMock()
+    context.application.create_task = MagicMock(return_value=MagicMock())
+    return context
+
+
+class TestDoSlskdSearch:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_no_results_all_fallbacks(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = AsyncMock()
+        bot.slskd.search = AsyncMock(return_value=[])
+        bot.slskd.parse_results = MagicMock(return_value=[])
+        bot.scorer = MagicMock()
+        bot.scorer.score_results = MagicMock(return_value=[])
+        bot._chat_generation[123] = 0
+
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_slskd_search(context, 123, _make_track(), msg, 0)
+        # Should have tried multiple fallback searches
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_finds_flac_results(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = AsyncMock()
+        bot.slskd.search = AsyncMock(return_value=[{"responses": []}])
+        results = [_make_result(0), _make_result(1)]
+        bot.slskd.parse_results = MagicMock(return_value=results)
+        bot.scorer = MagicMock()
+        bot.scorer.score_results = MagicMock(return_value=results)
+        bot._chat_generation[123] = 0
+
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_slskd_search(context, 123, _make_track(), msg, 0)
+        assert 123 in bot.pending
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_non_flac_fallback(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = AsyncMock()
+        bot.slskd.search = AsyncMock(return_value=[])
+        call_count = 0
+
+        def parse_side_effect(responses, flac_only=True):
+            nonlocal call_count
+            call_count += 1
+            if not flac_only and call_count >= 2:
+                return [_make_result(0, "mp3")]
+            return []
+
+        bot.slskd.parse_results = MagicMock(side_effect=parse_side_effect)
+        score_count = 0
+
+        def score_side_effect(results, track, **kwargs):
+            nonlocal score_count
+            score_count += 1
+            return results if results else []
+
+        bot.scorer = MagicMock()
+        bot.scorer.score_results = MagicMock(side_effect=score_side_effect)
+        bot._chat_generation[123] = 0
+
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_slskd_search(context, 123, _make_track(), msg, 0)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_stale_aborts_early(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = AsyncMock()
+        bot.slskd.search = AsyncMock(return_value=[])
+        bot.slskd.parse_results = MagicMock(return_value=[])
+        bot.scorer = MagicMock()
+        bot.scorer.score_results = MagicMock(return_value=[])
+        bot._chat_generation[123] = 5  # generation is ahead
+
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_slskd_search(context, 123, _make_track(), msg, 0)
+        assert 123 not in bot.pending
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_exception_handled(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = AsyncMock()
+        bot.slskd.search = AsyncMock(side_effect=Exception("Network error"))
+        bot._chat_generation[123] = 0
+
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock()
+        msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_slskd_search(context, 123, _make_track(), msg, 0)
+        # Should not raise
+
+
+class TestDoDownload:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_enqueue_fails(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = MagicMock()
+        bot.slskd.enqueue_download = MagicMock(return_value=False)
+
+        status_msg = AsyncMock()
+        status_msg.edit_text = AsyncMock()
+        status_msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_download(context, 123, _make_track(), _make_result(), status_msg)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_download_failed_status(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = MagicMock()
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        failed_status = DownloadStatus(username="u", filename="f", state="Errored")
+        bot.slskd.wait_for_download = AsyncMock(return_value=failed_status)
+
+        status_msg = AsyncMock()
+        status_msg.edit_text = AsyncMock()
+        status_msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_download(context, 123, _make_track(), _make_result(), status_msg)
+        assert any(h["status"] == "failed" for h in bot.history)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_download_timeout(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = MagicMock()
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        bot.slskd.wait_for_download = AsyncMock(return_value=None)
+
+        status_msg = AsyncMock()
+        status_msg.edit_text = AsyncMock()
+        status_msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_download(context, 123, _make_track(), _make_result(), status_msg)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_file_not_found_on_disk(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = MagicMock()
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        completed = DownloadStatus(username="u", filename="f", state="Completed, Succeeded")
+        bot.slskd.wait_for_download = AsyncMock(return_value=completed)
+        bot.processor = MagicMock()
+        bot.processor.find_downloaded_file = MagicMock(return_value=None)
+
+        status_msg = AsyncMock()
+        status_msg.edit_text = AsyncMock()
+        status_msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_download(context, 123, _make_track(), _make_result(), status_msg)
+        assert any(h["status"] == "file_not_found" for h in bot.history)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_successful_download_small_file(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = MagicMock()
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        completed = DownloadStatus(username="u", filename="f", state="Completed, Succeeded")
+        bot.slskd.wait_for_download = AsyncMock(return_value=completed)
+
+        # Create a real small temp file
+        with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as f:
+            f.write(b"\x00" * 1000)
+            source_path = f.name
+
+        try:
+            bot.processor = MagicMock()
+            bot.processor.find_downloaded_file = MagicMock(return_value=source_path)
+            bot.processor.build_filename = MagicMock(return_value="Artist - Song.flac")
+            bot._analyze_flac = AsyncMock(return_value=FlacVerdict(
+                verdict="AUTHENTIC", cutoff_khz=22.05, nyquist_khz=22.05,
+                sample_rate=44100, bit_depth=16,
+            ))
+
+            status_msg = AsyncMock()
+            status_msg.edit_text = AsyncMock()
+            status_msg.message_id = 1
+
+            sent_msg = AsyncMock()
+            sent_msg.message_id = 2
+
+            context = _make_context()
+            context.bot.send_audio = AsyncMock(return_value=sent_msg)
+
+            result = _make_result()
+            await bot._do_download(context, 123, _make_track(), result, status_msg)
+            context.bot.send_audio.assert_called_once()
+        finally:
+            os.unlink(source_path)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_send_audio_bad_request_falls_back_to_document(self, mock_slskd_cls, mock_spotify):
+        from telegram.error import BadRequest
+
+        bot = MusicBot(_make_config())
+        bot.slskd = MagicMock()
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        completed = DownloadStatus(username="u", filename="f", state="Completed, Succeeded")
+        bot.slskd.wait_for_download = AsyncMock(return_value=completed)
+
+        with tempfile.NamedTemporaryFile(suffix=".flac", delete=False) as f:
+            f.write(b"\x00" * 1000)
+            source_path = f.name
+
+        try:
+            bot.processor = MagicMock()
+            bot.processor.find_downloaded_file = MagicMock(return_value=source_path)
+            bot.processor.build_filename = MagicMock(return_value="Artist - Song.flac")
+            bot._analyze_flac = AsyncMock(return_value=None)
+
+            status_msg = AsyncMock()
+            status_msg.edit_text = AsyncMock()
+            status_msg.message_id = 1
+
+            sent_msg = AsyncMock()
+            sent_msg.message_id = 2
+
+            context = _make_context()
+            context.bot.send_audio = AsyncMock(side_effect=BadRequest("file too large"))
+            context.bot.send_document = AsyncMock(return_value=sent_msg)
+
+            await bot._do_download(context, 123, _make_track(), _make_result(), status_msg)
+            context.bot.send_document.assert_called_once()
+        finally:
+            os.unlink(source_path)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_download_exception(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = MagicMock()
+        bot.slskd.enqueue_download = MagicMock(side_effect=Exception("unexpected"))
+
+        status_msg = AsyncMock()
+        status_msg.edit_text = AsyncMock()
+        status_msg.message_id = 1
+
+        context = _make_context()
+        await bot._do_download(context, 123, _make_track(), _make_result(), status_msg)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_non_flac_skips_analysis(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot.slskd = MagicMock()
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        completed = DownloadStatus(username="u", filename="f", state="Completed")
+        bot.slskd.wait_for_download = AsyncMock(return_value=completed)
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            f.write(b"\x00" * 1000)
+            source_path = f.name
+
+        try:
+            bot.processor = MagicMock()
+            bot.processor.find_downloaded_file = MagicMock(return_value=source_path)
+            bot.processor.build_filename = MagicMock(return_value="Artist - Song.mp3")
+            bot._analyze_flac = AsyncMock()
+
+            status_msg = AsyncMock()
+            status_msg.edit_text = AsyncMock()
+            status_msg.message_id = 1
+
+            sent_msg = AsyncMock()
+            sent_msg.message_id = 2
+            context = _make_context()
+            context.bot.send_audio = AsyncMock(return_value=sent_msg)
+
+            mp3_result = _make_result(ext="mp3")
+            await bot._do_download(context, 123, _make_track(), mp3_result, status_msg)
+            bot._analyze_flac.assert_not_called()
+        finally:
+            os.unlink(source_path)
+
+
+class TestSendLargeFile:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_ogg_conversion_success_small_enough(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+
+        with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+            f.write(b"\x00" * 1000)
+            ogg_path = f.name
+
+        try:
+            bot._convert_to_ogg = AsyncMock(return_value=ogg_path)
+            bot.processor = MagicMock()
+            bot.processor.build_filename = MagicMock(return_value="Artist - Song.ogg")
+
+            sent_msg = AsyncMock()
+            sent_msg.message_id = 2
+            context = _make_context()
+            context.bot.send_audio = AsyncMock(return_value=sent_msg)
+
+            await bot._send_large_file(
+                context, 123, _make_track(), _make_result(),
+                "/fake/source.flac", 60_000_000, "Quality line", "#1", "dl1",
+            )
+            context.bot.send_audio.assert_called_once()
+        finally:
+            if os.path.exists(ogg_path):
+                os.unlink(ogg_path)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_ogg_too_large_falls_back_to_preview(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+
+        # Create a fake "large" OGG (we'll mock the size check)
+        with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+            f.write(b"\x00" * 100)
+            ogg_path = f.name
+
+        with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+            f.write(b"\x00" * 100)
+            preview_path = f.name
+
+        try:
+            bot._convert_to_ogg = AsyncMock(return_value=ogg_path)
+            bot._create_preview = AsyncMock(return_value=preview_path)
+            bot.processor = MagicMock()
+            bot.processor.build_filename = MagicMock(return_value="Artist - Song.ogg")
+
+            sent_msg = AsyncMock()
+            sent_msg.message_id = 2
+            context = _make_context()
+            context.bot.send_audio = AsyncMock(return_value=sent_msg)
+
+            # Patch os.path.getsize to return large size for OGG
+            orig_getsize = os.path.getsize
+            def mock_getsize(path):
+                if path == ogg_path:
+                    return 60_000_000  # > 50MB limit
+                return orig_getsize(path)
+
+            with patch("music_downloader.bot.handlers.os.path.getsize", side_effect=mock_getsize):
+                await bot._send_large_file(
+                    context, 123, _make_track(), _make_result(),
+                    "/fake/source.flac", 70_000_000, "Quality", "#1", "dl1",
+                )
+        finally:
+            for p in (ogg_path, preview_path):
+                if os.path.exists(p):
+                    os.unlink(p)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_ogg_conversion_fails_uses_preview(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+
+        with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+            f.write(b"\x00" * 100)
+            preview_path = f.name
+
+        try:
+            bot._convert_to_ogg = AsyncMock(return_value=None)
+            bot._create_preview = AsyncMock(return_value=preview_path)
+            bot.processor = MagicMock()
+            bot.processor.build_filename = MagicMock(return_value="Artist - Song.ogg")
+
+            sent_msg = AsyncMock()
+            sent_msg.message_id = 2
+            context = _make_context()
+            context.bot.send_audio = AsyncMock(return_value=sent_msg)
+
+            await bot._send_large_file(
+                context, 123, _make_track(), _make_result(),
+                "/fake/source.flac", 60_000_000, "Quality", "#1", "dl1",
+            )
+        finally:
+            if os.path.exists(preview_path):
+                os.unlink(preview_path)
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_both_conversions_fail(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        bot._convert_to_ogg = AsyncMock(return_value=None)
+        bot._create_preview = AsyncMock(return_value=None)
+
+        sent_msg = AsyncMock()
+        sent_msg.message_id = 2
+        context = _make_context()
+        context.bot.send_message = AsyncMock(return_value=sent_msg)
+
+        await bot._send_large_file(
+            context, 123, _make_track(), _make_result(),
+            "/fake/source.flac", 60_000_000, "Quality", "#1", "dl1",
+        )
+        context.bot.send_message.assert_called_once()
+
+
+class TestAsyncHelpers:
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_analyze_flac_runs(self, mock_slskd_cls, mock_spotify):
+        with patch("music_downloader.bot.handlers.analyze_flac") as mock_analyze:
+            mock_analyze.return_value = FlacVerdict(
+                verdict="AUTHENTIC", cutoff_khz=22.05, nyquist_khz=22.05,
+                sample_rate=44100, bit_depth=16,
+            )
+            result = await MusicBot._analyze_flac("/fake/path.flac")
+            assert result is not None
+            assert result.verdict == "AUTHENTIC"
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_analyze_flac_exception(self, mock_slskd_cls, mock_spotify):
+        with patch("music_downloader.bot.handlers.analyze_flac") as mock_analyze:
+            mock_analyze.side_effect = Exception("read error")
+            result = await MusicBot._analyze_flac("/fake/path.flac")
+            assert result is None
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_convert_to_ogg_runs(self, mock_slskd_cls, mock_spotify):
+        with patch("music_downloader.bot.handlers.convert_to_ogg") as mock_conv:
+            mock_conv.return_value = "/tmp/output.ogg"
+            result = await MusicBot._convert_to_ogg("/fake/path.flac")
+            assert result == "/tmp/output.ogg"
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_convert_to_ogg_exception(self, mock_slskd_cls, mock_spotify):
+        with patch("music_downloader.bot.handlers.convert_to_ogg") as mock_conv:
+            mock_conv.side_effect = Exception("ffmpeg error")
+            result = await MusicBot._convert_to_ogg("/fake/path.flac")
+            assert result is None
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_create_preview_runs(self, mock_slskd_cls, mock_spotify):
+        with patch("music_downloader.bot.handlers.create_preview_clip") as mock_clip:
+            mock_clip.return_value = "/tmp/preview.ogg"
+            result = await MusicBot._create_preview("/fake/path.flac", 60.0)
+            assert result == "/tmp/preview.ogg"
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_create_preview_exception(self, mock_slskd_cls, mock_spotify):
+        with patch("music_downloader.bot.handlers.create_preview_clip") as mock_clip:
+            mock_clip.side_effect = Exception("ffmpeg error")
+            result = await MusicBot._create_preview("/fake/path.flac")
+            assert result is None
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_embed_spotify_artwork_success(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        with patch("music_downloader.bot.handlers.fetch_spotify_artwork") as mock_fetch:
+            mock_fetch.return_value = b"\xff\xd8\xff\xe0"
+            with patch("music_downloader.bot.handlers.embed_artwork_into_file") as mock_embed:
+                mock_embed.return_value = True
+                await bot._embed_spotify_artwork("/fake/path.flac", _make_track())
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_embed_spotify_artwork_no_art(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        with patch("music_downloader.bot.handlers.fetch_spotify_artwork") as mock_fetch:
+            mock_fetch.return_value = None
+            await bot._embed_spotify_artwork("/fake/path.flac", _make_track())
+
+    @patch("music_downloader.bot.handlers.SpotifyResolver")
+    @patch("music_downloader.bot.handlers.SlskdClient")
+    @pytest.mark.asyncio
+    async def test_embed_spotify_artwork_exception(self, mock_slskd_cls, mock_spotify):
+        bot = MusicBot(_make_config())
+        with patch("music_downloader.bot.handlers.fetch_spotify_artwork") as mock_fetch:
+            mock_fetch.side_effect = Exception("network error")
+            # Should not raise
+            await bot._embed_spotify_artwork("/fake/path.flac", _make_track())
+
+
+class TestCreateBot:
+    def test_creates_application(self):
+        config = _make_config()
+        with patch("music_downloader.bot.handlers.Application") as mock_app_cls:
+            mock_builder = MagicMock()
+            mock_app = MagicMock()
+            mock_builder.token.return_value = mock_builder
+            mock_builder.build.return_value = mock_app
+            mock_app_cls.builder.return_value = mock_builder
+
+            app = create_bot(config)
+            assert app is mock_app
+            mock_app.add_handler.assert_called()
+            # Should have 5 command handlers + 1 callback + 1 message = 7
+            assert mock_app.add_handler.call_count == 7

--- a/tests/test_handlers_download.py
+++ b/tests/test_handlers_download.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from music_downloader.bot.handlers import MusicBot, PendingDownload, PendingSearch, create_bot
+from music_downloader.bot.handlers import MusicBot, create_bot
 from music_downloader.metadata.spotify import TrackInfo
 from music_downloader.processor.flac_analyzer import FlacVerdict
 from music_downloader.search.slskd_client import DownloadStatus, SearchResult
-
 
 _tmp_dir = None
 

--- a/tests/test_handlers_download.py
+++ b/tests/test_handlers_download.py
@@ -46,9 +46,12 @@ def _make_config():
 
 def _make_track():
     return TrackInfo(
-        artist="Nancy Sinatra", title="Bang Bang",
-        album="How Does That Grab You?", duration_ms=162_000,
-        spotify_url="https://open.spotify.com/track/xxx", year="1966",
+        artist="Nancy Sinatra",
+        title="Bang Bang",
+        album="How Does That Grab You?",
+        duration_ms=162_000,
+        spotify_url="https://open.spotify.com/track/xxx",
+        year="1966",
     )
 
 
@@ -56,8 +59,14 @@ def _make_result(idx=0, ext="flac"):
     return SearchResult(
         username=f"user{idx}",
         filename=f"\\Music\\Nancy Sinatra - Bang Bang {idx}.{ext}",
-        size=30_000_000, bit_rate=900, bit_depth=16, sample_rate=44100,
-        length=162, has_free_slot=True, upload_speed=1_000_000, queue_length=0,
+        size=30_000_000,
+        bit_rate=900,
+        bit_depth=16,
+        sample_rate=44100,
+        length=162,
+        has_free_slot=True,
+        upload_speed=1_000_000,
+        queue_length=0,
     )
 
 
@@ -279,10 +288,15 @@ class TestDoDownload:
             bot.processor = MagicMock()
             bot.processor.find_downloaded_file = MagicMock(return_value=source_path)
             bot.processor.build_filename = MagicMock(return_value="Artist - Song.flac")
-            bot._analyze_flac = AsyncMock(return_value=FlacVerdict(
-                verdict="AUTHENTIC", cutoff_khz=22.05, nyquist_khz=22.05,
-                sample_rate=44100, bit_depth=16,
-            ))
+            bot._analyze_flac = AsyncMock(
+                return_value=FlacVerdict(
+                    verdict="AUTHENTIC",
+                    cutoff_khz=22.05,
+                    nyquist_khz=22.05,
+                    sample_rate=44100,
+                    bit_depth=16,
+                )
+            )
 
             status_msg = AsyncMock()
             status_msg.edit_text = AsyncMock()
@@ -411,8 +425,15 @@ class TestSendLargeFile:
             context.bot.send_audio = AsyncMock(return_value=sent_msg)
 
             await bot._send_large_file(
-                context, 123, _make_track(), _make_result(),
-                "/fake/source.flac", 60_000_000, "Quality line", "#1", "dl1",
+                context,
+                123,
+                _make_track(),
+                _make_result(),
+                "/fake/source.flac",
+                60_000_000,
+                "Quality line",
+                "#1",
+                "dl1",
             )
             context.bot.send_audio.assert_called_once()
         finally:
@@ -447,6 +468,7 @@ class TestSendLargeFile:
 
             # Patch os.path.getsize to return large size for OGG
             orig_getsize = os.path.getsize
+
             def mock_getsize(path):
                 if path == ogg_path:
                     return 60_000_000  # > 50MB limit
@@ -454,8 +476,15 @@ class TestSendLargeFile:
 
             with patch("music_downloader.bot.handlers.os.path.getsize", side_effect=mock_getsize):
                 await bot._send_large_file(
-                    context, 123, _make_track(), _make_result(),
-                    "/fake/source.flac", 70_000_000, "Quality", "#1", "dl1",
+                    context,
+                    123,
+                    _make_track(),
+                    _make_result(),
+                    "/fake/source.flac",
+                    70_000_000,
+                    "Quality",
+                    "#1",
+                    "dl1",
                 )
         finally:
             for p in (ogg_path, preview_path):
@@ -484,8 +513,15 @@ class TestSendLargeFile:
             context.bot.send_audio = AsyncMock(return_value=sent_msg)
 
             await bot._send_large_file(
-                context, 123, _make_track(), _make_result(),
-                "/fake/source.flac", 60_000_000, "Quality", "#1", "dl1",
+                context,
+                123,
+                _make_track(),
+                _make_result(),
+                "/fake/source.flac",
+                60_000_000,
+                "Quality",
+                "#1",
+                "dl1",
             )
         finally:
             if os.path.exists(preview_path):
@@ -505,8 +541,15 @@ class TestSendLargeFile:
         context.bot.send_message = AsyncMock(return_value=sent_msg)
 
         await bot._send_large_file(
-            context, 123, _make_track(), _make_result(),
-            "/fake/source.flac", 60_000_000, "Quality", "#1", "dl1",
+            context,
+            123,
+            _make_track(),
+            _make_result(),
+            "/fake/source.flac",
+            60_000_000,
+            "Quality",
+            "#1",
+            "dl1",
         )
         context.bot.send_message.assert_called_once()
 
@@ -518,8 +561,11 @@ class TestAsyncHelpers:
     async def test_analyze_flac_runs(self, mock_slskd_cls, mock_spotify):
         with patch("music_downloader.bot.handlers.analyze_flac") as mock_analyze:
             mock_analyze.return_value = FlacVerdict(
-                verdict="AUTHENTIC", cutoff_khz=22.05, nyquist_khz=22.05,
-                sample_rate=44100, bit_depth=16,
+                verdict="AUTHENTIC",
+                cutoff_khz=22.05,
+                nyquist_khz=22.05,
+                sample_rate=44100,
+                bit_depth=16,
             )
             result = await MusicBot._analyze_flac("/fake/path.flac")
             assert result is not None

--- a/tests/test_keyboards.py
+++ b/tests/test_keyboards.py
@@ -1,0 +1,166 @@
+"""Tests for inline keyboard builders."""
+
+from music_downloader.bot.keyboards import (
+    build_approve_keyboard,
+    build_auto_mode_keyboard,
+    build_duplicate_keyboard,
+    build_results_keyboard,
+    build_spotify_keyboard,
+)
+from music_downloader.metadata.spotify import TrackInfo
+from music_downloader.search.slskd_client import SearchResult
+
+
+def _make_result(idx: int = 0) -> SearchResult:
+    return SearchResult(
+        username=f"user{idx}",
+        filename=f"\\Music\\file{idx}.flac",
+        size=30_000_000,
+        bit_rate=900,
+        bit_depth=16,
+        sample_rate=44100,
+        length=180,
+        has_free_slot=True,
+        upload_speed=1_000_000,
+        queue_length=0,
+    )
+
+
+def _make_track(idx: int = 0) -> TrackInfo:
+    return TrackInfo(
+        artist=f"Artist{idx}",
+        title=f"Title{idx}",
+        album=f"Album{idx}",
+        duration_ms=180_000,
+        spotify_url=f"https://open.spotify.com/track/{idx}",
+        year="2024",
+    )
+
+
+class TestBuildResultsKeyboard:
+    def test_single_result(self):
+        results = [_make_result()]
+        kb = build_results_keyboard(results)
+        rows = kb.inline_keyboard
+        # 1 result button + action row (auto-pick + cancel)
+        assert len(rows) == 2
+        assert "dl:0" in rows[0][0].callback_data
+
+    def test_multiple_results(self):
+        results = [_make_result(i) for i in range(3)]
+        kb = build_results_keyboard(results)
+        rows = kb.inline_keyboard
+        # 3 result rows + action row
+        assert len(rows) == 4
+
+    def test_pagination_first_page(self):
+        results = [_make_result(i) for i in range(15)]
+        kb = build_results_keyboard(results, page=0, page_size=10)
+        rows = kb.inline_keyboard
+        # 10 result rows + nav row + action row
+        nav_row = rows[-2]
+        assert any("Next" in btn.text for btn in nav_row)
+        assert not any("Prev" in btn.text for btn in nav_row)
+
+    def test_pagination_second_page(self):
+        results = [_make_result(i) for i in range(15)]
+        kb = build_results_keyboard(results, page=1, page_size=10)
+        rows = kb.inline_keyboard
+        nav_row = rows[-2]
+        assert any("Prev" in btn.text for btn in nav_row)
+        assert not any("Next" in btn.text for btn in nav_row)
+
+    def test_pagination_middle_page(self):
+        results = [_make_result(i) for i in range(30)]
+        kb = build_results_keyboard(results, page=1, page_size=10)
+        rows = kb.inline_keyboard
+        nav_row = rows[-2]
+        assert any("Prev" in btn.text for btn in nav_row)
+        assert any("Next" in btn.text for btn in nav_row)
+
+    def test_action_row_has_auto_and_cancel(self):
+        results = [_make_result()]
+        kb = build_results_keyboard(results)
+        action_row = kb.inline_keyboard[-1]
+        texts = [btn.text for btn in action_row]
+        assert any("Auto" in t for t in texts)
+        assert any("Cancel" in t for t in texts)
+
+    def test_empty_results_has_cancel_only(self):
+        kb = build_results_keyboard([])
+        action_row = kb.inline_keyboard[-1]
+        assert len(action_row) == 1
+        assert "Cancel" in action_row[0].text
+
+
+class TestBuildApproveKeyboard:
+    def test_has_approve_and_reject(self):
+        kb = build_approve_keyboard("42")
+        buttons = kb.inline_keyboard[0]
+        assert len(buttons) == 2
+        assert buttons[0].callback_data == "approve:42"
+        assert buttons[1].callback_data == "reject:42"
+
+
+class TestBuildDuplicateKeyboard:
+    def test_has_continue_and_cancel(self):
+        kb = build_duplicate_keyboard()
+        buttons = kb.inline_keyboard[0]
+        assert len(buttons) == 2
+        assert buttons[0].callback_data == "dup:continue"
+        assert buttons[1].callback_data == "dup:cancel"
+
+
+class TestBuildSpotifyKeyboard:
+    def test_single_page(self):
+        tracks = [_make_track(i) for i in range(3)]
+        kb = build_spotify_keyboard(tracks)
+        rows = kb.inline_keyboard
+        # 3 track buttons + cancel row
+        assert len(rows) == 4
+        assert rows[0][0].callback_data == "sp:0"
+        assert rows[-1][0].callback_data == "sp:cancel"
+
+    def test_pagination_multiple_pages(self):
+        tracks = [_make_track(i) for i in range(12)]
+        kb = build_spotify_keyboard(tracks, page=0, page_size=5)
+        rows = kb.inline_keyboard
+        # 5 track rows + nav row + cancel row
+        nav_row = rows[-2]
+        assert any("Next" in btn.text for btn in nav_row)
+
+    def test_pagination_last_page(self):
+        tracks = [_make_track(i) for i in range(12)]
+        kb = build_spotify_keyboard(tracks, page=2, page_size=5)
+        rows = kb.inline_keyboard
+        # 2 track rows + nav row + cancel row
+        nav_row = rows[-2]
+        assert any("Prev" in btn.text for btn in nav_row)
+        assert not any("Next" in btn.text for btn in nav_row)
+
+    def test_truncates_long_labels(self):
+        track = TrackInfo(
+            artist="A Very Long Artist Name That Goes On",
+            title="A Very Long Song Title That Is Excessively Verbose And Long",
+            album="Album",
+            duration_ms=180_000,
+            spotify_url="",
+            year="2024",
+        )
+        kb = build_spotify_keyboard([track])
+        label = kb.inline_keyboard[0][0].text
+        assert len(label) <= 64
+
+
+class TestBuildAutoModeKeyboard:
+    def test_currently_on(self):
+        kb = build_auto_mode_keyboard(True)
+        btn = kb.inline_keyboard[0][0]
+        assert "Disable" in btn.text
+        assert btn.callback_data == "auto:off"
+
+    def test_currently_off(self):
+        kb = build_auto_mode_keyboard(False)
+        btn = kb.inline_keyboard[0][0]
+        assert "Enable" in btn.text
+        assert btn.callback_data == "auto:on"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,44 @@
+"""Tests for __main__ module."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from music_downloader.__main__ import create_health_app, main
+
+
+class TestCreateHealthApp:
+    def test_creates_app(self):
+        app = create_health_app()
+        assert app.title == "Music Downloader"
+        # Verify the health route exists
+        routes = [r.path for r in app.routes]
+        assert "/health" in routes
+
+
+class TestMain:
+    def test_version_flag(self):
+        with patch.object(sys, "argv", ["slskd-importer", "--version"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+
+    def test_default_command_is_run(self):
+        """Without a subcommand, main defaults to 'run'."""
+        with patch.object(sys, "argv", ["slskd-importer"]):
+            with patch("music_downloader.__main__.cmd_run") as mock_run:
+                main()
+                mock_run.assert_called_once()
+
+    def test_run_subcommand(self):
+        with patch.object(sys, "argv", ["slskd-importer", "run"]):
+            with patch("music_downloader.__main__.cmd_run") as mock_run:
+                main()
+                mock_run.assert_called_once()
+
+    def test_unknown_command(self):
+        with patch.object(sys, "argv", ["slskd-importer", "unknown"]):
+            with pytest.raises(SystemExit):
+                main()
+
+
+import pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,9 @@
 """Tests for __main__ module."""
 
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
+
+import pytest
 
 from music_downloader.__main__ import create_health_app, main
 
@@ -17,28 +19,21 @@ class TestCreateHealthApp:
 
 class TestMain:
     def test_version_flag(self):
-        with patch.object(sys, "argv", ["slskd-importer", "--version"]):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            assert exc_info.value.code == 0
+        with patch.object(sys, "argv", ["slskd-importer", "--version"]), pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
 
     def test_default_command_is_run(self):
         """Without a subcommand, main defaults to 'run'."""
-        with patch.object(sys, "argv", ["slskd-importer"]):
-            with patch("music_downloader.__main__.cmd_run") as mock_run:
-                main()
-                mock_run.assert_called_once()
+        with patch.object(sys, "argv", ["slskd-importer"]), patch("music_downloader.__main__.cmd_run") as mock_run:
+            main()
+            mock_run.assert_called_once()
 
     def test_run_subcommand(self):
-        with patch.object(sys, "argv", ["slskd-importer", "run"]):
-            with patch("music_downloader.__main__.cmd_run") as mock_run:
-                main()
-                mock_run.assert_called_once()
+        with patch.object(sys, "argv", ["slskd-importer", "run"]), patch("music_downloader.__main__.cmd_run") as mock_run:
+            main()
+            mock_run.assert_called_once()
 
     def test_unknown_command(self):
-        with patch.object(sys, "argv", ["slskd-importer", "unknown"]):
-            with pytest.raises(SystemExit):
-                main()
-
-
-import pytest
+        with patch.object(sys, "argv", ["slskd-importer", "unknown"]), pytest.raises(SystemExit):
+            main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,10 @@ class TestMain:
             mock_run.assert_called_once()
 
     def test_run_subcommand(self):
-        with patch.object(sys, "argv", ["slskd-importer", "run"]), patch("music_downloader.__main__.cmd_run") as mock_run:
+        with (
+            patch.object(sys, "argv", ["slskd-importer", "run"]),
+            patch("music_downloader.__main__.cmd_run") as mock_run,
+        ):
             main()
             mock_run.assert_called_once()
 

--- a/tests/test_main_extended.py
+++ b/tests/test_main_extended.py
@@ -1,0 +1,38 @@
+"""Extended tests for __main__ - covering run_health_server and cmd_run."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from music_downloader.__main__ import cmd_run, create_health_app, run_health_server
+
+
+class TestRunHealthServer:
+    def test_creates_and_runs_server(self):
+        with patch("music_downloader.__main__.uvicorn") as mock_uvicorn:
+            mock_server = MagicMock()
+            mock_uvicorn.Config.return_value = MagicMock()
+            mock_uvicorn.Server.return_value = mock_server
+            run_health_server(8080)
+            mock_server.run.assert_called_once()
+
+
+class TestCmdRun:
+    def test_cmd_run_starts_bot(self):
+        env = {
+            "TELEGRAM_BOT_TOKEN": "t",
+            "SPOTIFY_CLIENT_ID": "s",
+            "SPOTIFY_CLIENT_SECRET": "ss",
+            "SLSKD_HOST": "h",
+            "SLSKD_API_KEY": "k",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch("music_downloader.__main__.create_bot") as mock_create:
+                mock_app = MagicMock()
+                mock_create.return_value = mock_app
+                with patch("music_downloader.__main__.threading.Thread") as mock_thread:
+                    mock_thread_instance = MagicMock()
+                    mock_thread.return_value = mock_thread_instance
+                    args = MagicMock()
+                    cmd_run(args)
+                    mock_thread_instance.start.assert_called_once()
+                    mock_app.run_polling.assert_called_once()

--- a/tests/test_main_extended.py
+++ b/tests/test_main_extended.py
@@ -3,7 +3,7 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from music_downloader.__main__ import cmd_run, create_health_app, run_health_server
+from music_downloader.__main__ import cmd_run, run_health_server
 
 
 class TestRunHealthServer:
@@ -25,14 +25,16 @@ class TestCmdRun:
             "SLSKD_HOST": "h",
             "SLSKD_API_KEY": "k",
         }
-        with patch.dict(os.environ, env, clear=False):
-            with patch("music_downloader.__main__.create_bot") as mock_create:
-                mock_app = MagicMock()
-                mock_create.return_value = mock_app
-                with patch("music_downloader.__main__.threading.Thread") as mock_thread:
-                    mock_thread_instance = MagicMock()
-                    mock_thread.return_value = mock_thread_instance
-                    args = MagicMock()
-                    cmd_run(args)
-                    mock_thread_instance.start.assert_called_once()
-                    mock_app.run_polling.assert_called_once()
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch("music_downloader.__main__.create_bot") as mock_create,
+            patch("music_downloader.__main__.threading.Thread") as mock_thread,
+        ):
+            mock_app = MagicMock()
+            mock_create.return_value = mock_app
+            mock_thread_instance = MagicMock()
+            mock_thread.return_value = mock_thread_instance
+            args = MagicMock()
+            cmd_run(args)
+            mock_thread_instance.start.assert_called_once()
+            mock_app.run_polling.assert_called_once()

--- a/tests/test_slskd_client.py
+++ b/tests/test_slskd_client.py
@@ -1,0 +1,409 @@
+"""Tests for slskd API client."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from music_downloader.search.slskd_client import (
+    ActiveDownload,
+    DownloadStatus,
+    SearchResult,
+    SlskdClient,
+)
+
+
+class TestSearchResult:
+    """Test SearchResult dataclass properties."""
+
+    def test_basename_with_backslash(self):
+        r = SearchResult(username="u", filename="\\Music\\Artist\\Song.flac", size=100)
+        assert r.basename == "Song.flac"
+
+    def test_basename_no_backslash(self):
+        r = SearchResult(username="u", filename="Song.flac", size=100)
+        assert r.basename == "Song.flac"
+
+    def test_extension(self):
+        r = SearchResult(username="u", filename="\\Music\\Song.flac", size=100)
+        assert r.extension == "flac"
+
+    def test_extension_mp3(self):
+        r = SearchResult(username="u", filename="\\Music\\Song.MP3", size=100)
+        assert r.extension == "mp3"
+
+    def test_extension_no_dot(self):
+        r = SearchResult(username="u", filename="noextension", size=100)
+        assert r.extension == ""
+
+    def test_duration_display_valid(self):
+        r = SearchResult(username="u", filename="f.flac", size=100, length=185)
+        assert r.duration_display == "3:05"
+
+    def test_duration_display_none(self):
+        r = SearchResult(username="u", filename="f.flac", size=100, length=None)
+        assert r.duration_display == "??:??"
+
+    def test_duration_display_zero(self):
+        r = SearchResult(username="u", filename="f.flac", size=100, length=0)
+        assert r.duration_display == "??:??"
+
+    def test_size_mb(self):
+        r = SearchResult(username="u", filename="f.flac", size=52_428_800)
+        assert r.size_mb == 50.0
+
+    def test_quality_display_full(self):
+        r = SearchResult(
+            username="u", filename="f.flac", size=100,
+            bit_depth=24, sample_rate=96000, bit_rate=2000,
+        )
+        assert "24bit" in r.quality_display
+        assert "96.0kHz" in r.quality_display
+        assert "2000kbps" in r.quality_display
+
+    def test_quality_display_bitrate_only(self):
+        r = SearchResult(
+            username="u", filename="f.flac", size=100,
+            bit_rate=320,
+        )
+        assert r.quality_display == "320kbps"
+
+    def test_quality_display_no_info(self):
+        r = SearchResult(username="u", filename="f.flac", size=100)
+        assert r.quality_display == "FLAC"
+
+    def test_str(self):
+        r = SearchResult(
+            username="u", filename="\\Music\\Song.flac", size=30_000_000,
+            length=180, bit_depth=16, sample_rate=44100,
+        )
+        s = str(r)
+        assert "Song.flac" in s
+        assert "3:00" in s
+
+    def test_quality_display_bit_depth_sample_rate_only(self):
+        r = SearchResult(
+            username="u", filename="f.flac", size=100,
+            bit_depth=16, sample_rate=44100,
+        )
+        assert "16bit/44.1kHz" in r.quality_display
+        assert "kbps" not in r.quality_display
+
+
+class TestDownloadStatus:
+    """Test DownloadStatus dataclass properties."""
+
+    def test_is_complete_completed(self):
+        s = DownloadStatus(username="u", filename="f", state="Completed, Succeeded")
+        assert s.is_complete is True
+
+    def test_is_complete_succeeded(self):
+        s = DownloadStatus(username="u", filename="f", state="Succeeded")
+        assert s.is_complete is True
+
+    def test_is_complete_in_progress(self):
+        s = DownloadStatus(username="u", filename="f", state="InProgress")
+        assert s.is_complete is False
+
+    def test_is_failed_errored(self):
+        s = DownloadStatus(username="u", filename="f", state="Errored")
+        assert s.is_failed is True
+
+    def test_is_failed_rejected(self):
+        s = DownloadStatus(username="u", filename="f", state="Rejected")
+        assert s.is_failed is True
+
+    def test_is_failed_timedout(self):
+        s = DownloadStatus(username="u", filename="f", state="TimedOut")
+        assert s.is_failed is True
+
+    def test_is_failed_cancelled(self):
+        s = DownloadStatus(username="u", filename="f", state="Cancelled")
+        assert s.is_failed is True
+
+    def test_is_failed_normal(self):
+        s = DownloadStatus(username="u", filename="f", state="InProgress")
+        assert s.is_failed is False
+
+    def test_is_active_in_progress(self):
+        s = DownloadStatus(username="u", filename="f", state="InProgress")
+        assert s.is_active is True
+
+    def test_is_active_complete(self):
+        s = DownloadStatus(username="u", filename="f", state="Completed")
+        assert s.is_active is False
+
+    def test_is_active_failed(self):
+        s = DownloadStatus(username="u", filename="f", state="Errored")
+        assert s.is_active is False
+
+
+class TestActiveDownload:
+    """Test ActiveDownload dataclass."""
+
+    def test_defaults(self):
+        sr = SearchResult(username="u", filename="f.flac", size=100)
+        ad = ActiveDownload(search_result=sr, track_filename="Artist - Title.flac")
+        assert ad.status is None
+        assert ad.local_path is None
+
+
+class TestSlskdClientParseResults:
+    """Test SlskdClient.parse_results."""
+
+    @pytest.fixture
+    def client(self):
+        with patch("slskd_api.SlskdClient"):
+            return SlskdClient("http://localhost:5030", "test-key")
+
+    def test_parse_flac_only(self, client):
+        responses = [
+            {
+                "username": "user1",
+                "hasFreeUploadSlot": True,
+                "uploadSpeed": 5_000_000,
+                "queueLength": 0,
+                "files": [
+                    {"filename": "\\Music\\Song.flac", "size": 30_000_000, "length": 180, "bitDepth": 16, "sampleRate": 44100},
+                    {"filename": "\\Music\\Song.mp3", "size": 10_000_000, "length": 180, "bitRate": 320},
+                ],
+            }
+        ]
+        results = client.parse_results(responses, flac_only=True)
+        assert len(results) == 1
+        assert results[0].extension == "flac"
+
+    def test_parse_all_audio(self, client):
+        responses = [
+            {
+                "username": "user1",
+                "hasFreeUploadSlot": False,
+                "uploadSpeed": 1_000_000,
+                "queueLength": 2,
+                "files": [
+                    {"filename": "\\Music\\Song.flac", "size": 30_000_000},
+                    {"filename": "\\Music\\Song.mp3", "size": 10_000_000},
+                    {"filename": "\\Music\\Song.ogg", "size": 8_000_000},
+                    {"filename": "\\Music\\cover.jpg", "size": 500_000},
+                ],
+            }
+        ]
+        results = client.parse_results(responses, flac_only=False)
+        assert len(results) == 3
+        exts = {r.extension for r in results}
+        assert "jpg" not in exts
+
+    def test_parse_empty_responses(self, client):
+        assert client.parse_results([], flac_only=True) == []
+
+    def test_parse_preserves_user_info(self, client):
+        responses = [
+            {
+                "username": "cooluser",
+                "hasFreeUploadSlot": True,
+                "uploadSpeed": 9_000_000,
+                "queueLength": 3,
+                "files": [
+                    {"filename": "\\Song.flac", "size": 100},
+                ],
+            }
+        ]
+        results = client.parse_results(responses, flac_only=True)
+        assert results[0].username == "cooluser"
+        assert results[0].has_free_slot is True
+        assert results[0].upload_speed == 9_000_000
+        assert results[0].queue_length == 3
+
+    def test_parse_missing_fields(self, client):
+        responses = [
+            {
+                "username": "u",
+                "files": [{"filename": "\\Song.flac", "size": 0}],
+            }
+        ]
+        results = client.parse_results(responses, flac_only=True)
+        assert len(results) == 1
+        assert results[0].has_free_slot is False
+        assert results[0].upload_speed == 0
+
+
+class TestSlskdClientEnqueue:
+    """Test SlskdClient.enqueue_download."""
+
+    @pytest.fixture
+    def client(self):
+        with patch("slskd_api.SlskdClient") as mock_cls:
+            c = SlskdClient("http://localhost:5030", "test-key")
+            c.client = mock_cls.return_value
+            return c
+
+    def test_enqueue_success(self, client):
+        result = SearchResult(
+            username="user1", filename="\\Music\\Song.flac", size=30_000_000,
+        )
+        client.client.transfers.enqueue = MagicMock()
+        assert client.enqueue_download(result) is True
+        client.client.transfers.enqueue.assert_called_once()
+
+    def test_enqueue_failure(self, client):
+        result = SearchResult(
+            username="user1", filename="\\Music\\Song.flac", size=30_000_000,
+        )
+        client.client.transfers.enqueue = MagicMock(side_effect=Exception("Connection error"))
+        assert client.enqueue_download(result) is False
+
+
+class TestSlskdClientGetDownloadStatus:
+    """Test SlskdClient.get_download_status."""
+
+    @pytest.fixture
+    def client(self):
+        with patch("slskd_api.SlskdClient") as mock_cls:
+            c = SlskdClient("http://localhost:5030", "test-key")
+            c.client = mock_cls.return_value
+            return c
+
+    def test_status_found(self, client):
+        client.client.transfers.get_downloads = MagicMock(return_value={
+            "directories": [
+                {
+                    "files": [
+                        {
+                            "filename": "\\Music\\Song.flac",
+                            "state": "Completed, Succeeded",
+                            "percentComplete": 100,
+                            "bytesTransferred": 30_000_000,
+                            "size": 30_000_000,
+                            "averageSpeed": 5_000_000,
+                        }
+                    ]
+                }
+            ]
+        })
+        status = client.get_download_status("user1", "\\Music\\Song.flac")
+        assert status is not None
+        assert status.is_complete is True
+        assert status.percent_complete == 100
+
+    def test_status_not_found(self, client):
+        client.client.transfers.get_downloads = MagicMock(return_value={
+            "directories": [{"files": []}]
+        })
+        status = client.get_download_status("user1", "\\Music\\Song.flac")
+        assert status is None
+
+    def test_status_no_downloads(self, client):
+        client.client.transfers.get_downloads = MagicMock(return_value=None)
+        status = client.get_download_status("user1", "\\Music\\Song.flac")
+        assert status is None
+
+    def test_status_exception(self, client):
+        client.client.transfers.get_downloads = MagicMock(side_effect=Exception("err"))
+        status = client.get_download_status("user1", "\\Music\\Song.flac")
+        assert status is None
+
+
+class TestSlskdClientSearch:
+    """Test SlskdClient.search async method."""
+
+    @pytest.fixture
+    def client(self):
+        with patch("slskd_api.SlskdClient") as mock_cls:
+            c = SlskdClient("http://localhost:5030", "test-key")
+            c.client = mock_cls.return_value
+            return c
+
+    @pytest.mark.asyncio
+    async def test_search_exception_returns_empty(self, client):
+        """search() should return empty list on exception."""
+        client.client.searches.get_all = MagicMock(side_effect=Exception("fail"))
+        client.client.searches.search_text = MagicMock(side_effect=Exception("fail"))
+        results = await client.search("test query", timeout_secs=2)
+        assert results == []
+
+
+class TestSlskdClientGetDownloadsDirectory:
+    """Test SlskdClient.get_downloads_directory."""
+
+    @pytest.fixture
+    def client(self):
+        with patch("slskd_api.SlskdClient") as mock_cls:
+            c = SlskdClient("http://localhost:5030", "test-key")
+            c.client = mock_cls.return_value
+            return c
+
+    def test_returns_list(self, client):
+        client.client.files.get_downloads_dir = MagicMock(return_value=[{"name": "file.flac"}])
+        result = client.get_downloads_directory()
+        assert result == [{"name": "file.flac"}]
+
+    def test_exception_returns_empty(self, client):
+        client.client.files.get_downloads_dir = MagicMock(side_effect=Exception("err"))
+        result = client.get_downloads_directory()
+        assert result == []
+
+
+class TestSlskdClientWaitForDownload:
+    """Test SlskdClient.wait_for_download async method."""
+
+    @pytest.fixture
+    def client(self):
+        with patch("slskd_api.SlskdClient") as mock_cls:
+            c = SlskdClient("http://localhost:5030", "test-key")
+            c.client = mock_cls.return_value
+            return c
+
+    @pytest.mark.asyncio
+    async def test_wait_completes(self, client):
+        """wait_for_download returns completed status."""
+        completed = DownloadStatus(
+            username="u", filename="f.flac", state="Completed, Succeeded",
+            percent_complete=100, bytes_transferred=100, size=100,
+        )
+        call_count = 0
+
+        def mock_get_status(username, filename):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                return completed
+            return DownloadStatus(username="u", filename="f.flac", state="InProgress", percent_complete=50)
+
+        client.get_download_status = mock_get_status
+        result = await client.wait_for_download("u", "f.flac", timeout_secs=10)
+        assert result is not None
+        assert result.is_complete
+
+    @pytest.mark.asyncio
+    async def test_wait_fails(self, client):
+        """wait_for_download returns failed status."""
+        failed = DownloadStatus(username="u", filename="f.flac", state="Errored")
+        client.get_download_status = MagicMock(return_value=failed)
+        result = await client.wait_for_download("u", "f.flac", timeout_secs=10)
+        assert result is not None
+        assert result.is_failed
+
+    @pytest.mark.asyncio
+    async def test_wait_timeout(self, client):
+        """wait_for_download returns None on timeout."""
+        in_progress = DownloadStatus(username="u", filename="f.flac", state="InProgress")
+        client.get_download_status = MagicMock(return_value=in_progress)
+        result = await client.wait_for_download("u", "f.flac", timeout_secs=1)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_wait_no_status_yet(self, client):
+        """wait_for_download handles None status during polling."""
+        call_count = 0
+        completed = DownloadStatus(username="u", filename="f.flac", state="Completed")
+
+        def mock_status(username, filename):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                return None
+            return completed
+
+        client.get_download_status = mock_status
+        result = await client.wait_for_download("u", "f.flac", timeout_secs=15)
+        assert result is not None
+        assert result.is_complete

--- a/tests/test_slskd_client.py
+++ b/tests/test_slskd_client.py
@@ -53,8 +53,12 @@ class TestSearchResult:
 
     def test_quality_display_full(self):
         r = SearchResult(
-            username="u", filename="f.flac", size=100,
-            bit_depth=24, sample_rate=96000, bit_rate=2000,
+            username="u",
+            filename="f.flac",
+            size=100,
+            bit_depth=24,
+            sample_rate=96000,
+            bit_rate=2000,
         )
         assert "24bit" in r.quality_display
         assert "96.0kHz" in r.quality_display
@@ -62,7 +66,9 @@ class TestSearchResult:
 
     def test_quality_display_bitrate_only(self):
         r = SearchResult(
-            username="u", filename="f.flac", size=100,
+            username="u",
+            filename="f.flac",
+            size=100,
             bit_rate=320,
         )
         assert r.quality_display == "320kbps"
@@ -73,8 +79,12 @@ class TestSearchResult:
 
     def test_str(self):
         r = SearchResult(
-            username="u", filename="\\Music\\Song.flac", size=30_000_000,
-            length=180, bit_depth=16, sample_rate=44100,
+            username="u",
+            filename="\\Music\\Song.flac",
+            size=30_000_000,
+            length=180,
+            bit_depth=16,
+            sample_rate=44100,
         )
         s = str(r)
         assert "Song.flac" in s
@@ -82,8 +92,11 @@ class TestSearchResult:
 
     def test_quality_display_bit_depth_sample_rate_only(self):
         r = SearchResult(
-            username="u", filename="f.flac", size=100,
-            bit_depth=16, sample_rate=44100,
+            username="u",
+            filename="f.flac",
+            size=100,
+            bit_depth=16,
+            sample_rate=44100,
         )
         assert "16bit/44.1kHz" in r.quality_display
         assert "kbps" not in r.quality_display
@@ -163,7 +176,13 @@ class TestSlskdClientParseResults:
                 "uploadSpeed": 5_000_000,
                 "queueLength": 0,
                 "files": [
-                    {"filename": "\\Music\\Song.flac", "size": 30_000_000, "length": 180, "bitDepth": 16, "sampleRate": 44100},
+                    {
+                        "filename": "\\Music\\Song.flac",
+                        "size": 30_000_000,
+                        "length": 180,
+                        "bitDepth": 16,
+                        "sampleRate": 44100,
+                    },
                     {"filename": "\\Music\\Song.mp3", "size": 10_000_000, "length": 180, "bitRate": 320},
                 ],
             }
@@ -238,7 +257,9 @@ class TestSlskdClientEnqueue:
 
     def test_enqueue_success(self, client):
         result = SearchResult(
-            username="user1", filename="\\Music\\Song.flac", size=30_000_000,
+            username="user1",
+            filename="\\Music\\Song.flac",
+            size=30_000_000,
         )
         client.client.transfers.enqueue = MagicMock()
         assert client.enqueue_download(result) is True
@@ -246,7 +267,9 @@ class TestSlskdClientEnqueue:
 
     def test_enqueue_failure(self, client):
         result = SearchResult(
-            username="user1", filename="\\Music\\Song.flac", size=30_000_000,
+            username="user1",
+            filename="\\Music\\Song.flac",
+            size=30_000_000,
         )
         client.client.transfers.enqueue = MagicMock(side_effect=Exception("Connection error"))
         assert client.enqueue_download(result) is False
@@ -263,31 +286,31 @@ class TestSlskdClientGetDownloadStatus:
             return c
 
     def test_status_found(self, client):
-        client.client.transfers.get_downloads = MagicMock(return_value={
-            "directories": [
-                {
-                    "files": [
-                        {
-                            "filename": "\\Music\\Song.flac",
-                            "state": "Completed, Succeeded",
-                            "percentComplete": 100,
-                            "bytesTransferred": 30_000_000,
-                            "size": 30_000_000,
-                            "averageSpeed": 5_000_000,
-                        }
-                    ]
-                }
-            ]
-        })
+        client.client.transfers.get_downloads = MagicMock(
+            return_value={
+                "directories": [
+                    {
+                        "files": [
+                            {
+                                "filename": "\\Music\\Song.flac",
+                                "state": "Completed, Succeeded",
+                                "percentComplete": 100,
+                                "bytesTransferred": 30_000_000,
+                                "size": 30_000_000,
+                                "averageSpeed": 5_000_000,
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
         status = client.get_download_status("user1", "\\Music\\Song.flac")
         assert status is not None
         assert status.is_complete is True
         assert status.percent_complete == 100
 
     def test_status_not_found(self, client):
-        client.client.transfers.get_downloads = MagicMock(return_value={
-            "directories": [{"files": []}]
-        })
+        client.client.transfers.get_downloads = MagicMock(return_value={"directories": [{"files": []}]})
         status = client.get_download_status("user1", "\\Music\\Song.flac")
         assert status is None
 
@@ -356,8 +379,12 @@ class TestSlskdClientWaitForDownload:
     async def test_wait_completes(self, client):
         """wait_for_download returns completed status."""
         completed = DownloadStatus(
-            username="u", filename="f.flac", state="Completed, Succeeded",
-            percent_complete=100, bytes_transferred=100, size=100,
+            username="u",
+            filename="f.flac",
+            state="Completed, Succeeded",
+            percent_complete=100,
+            bytes_transferred=100,
+            size=100,
         )
         call_count = 0
 

--- a/tests/test_slskd_search_inner.py
+++ b/tests/test_slskd_search_inner.py
@@ -80,9 +80,12 @@ class TestSearchInner:
     @pytest.mark.asyncio
     async def test_cleanup_stale_searches(self, client):
         """Stale searches are cleaned up before new search."""
-        client.client.searches.get_all = MagicMock(return_value=[
-            {"id": "old-1"}, {"id": "old-2"},
-        ])
+        client.client.searches.get_all = MagicMock(
+            return_value=[
+                {"id": "old-1"},
+                {"id": "old-2"},
+            ]
+        )
         client.client.searches.delete = MagicMock()
         client.client.searches.search_text = MagicMock(return_value={"id": "new-1"})
 
@@ -126,10 +129,12 @@ class TestStopAndCollect:
     @pytest.mark.asyncio
     async def test_stop_and_collect_with_responses(self, client):
         client.client.searches.stop = MagicMock()
-        client.client.searches.state = MagicMock(return_value={
-            "responses": [{"username": "u1"}, {"username": "u2"}],
-            "responseCount": 2,
-        })
+        client.client.searches.state = MagicMock(
+            return_value={
+                "responses": [{"username": "u1"}, {"username": "u2"}],
+                "responseCount": 2,
+            }
+        )
         client.client.searches.delete = MagicMock()
 
         results = await client._stop_and_collect("search-1")
@@ -138,10 +143,12 @@ class TestStopAndCollect:
     @pytest.mark.asyncio
     async def test_stop_and_collect_fallback(self, client):
         client.client.searches.stop = MagicMock()
-        client.client.searches.state = MagicMock(return_value={
-            "responses": [],
-            "responseCount": 3,
-        })
+        client.client.searches.state = MagicMock(
+            return_value={
+                "responses": [],
+                "responseCount": 3,
+            }
+        )
         client.client.searches.search_responses = MagicMock(return_value=[{"username": "u"}])
         client.client.searches.delete = MagicMock()
 

--- a/tests/test_slskd_search_inner.py
+++ b/tests/test_slskd_search_inner.py
@@ -1,6 +1,6 @@
 """Tests for SlskdClient._search_inner and _stop_and_collect."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_slskd_search_inner.py
+++ b/tests/test_slskd_search_inner.py
@@ -1,0 +1,158 @@
+"""Tests for SlskdClient._search_inner and _stop_and_collect."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_downloader.search.slskd_client import SlskdClient
+
+
+class TestSearchInner:
+    @pytest.fixture
+    def client(self):
+        with patch("slskd_api.SlskdClient") as mock_cls:
+            c = SlskdClient("http://localhost:5030", "test-key")
+            c.client = mock_cls.return_value
+            return c
+
+    @pytest.mark.asyncio
+    async def test_search_completes_normally(self, client):
+        """Search completes when isComplete=True."""
+        client.client.searches.get_all = MagicMock(return_value=[])
+        client.client.searches.search_text = MagicMock(return_value={"id": "search-1"})
+        call_count = 0
+
+        def state_side_effect(id, includeResponses=False):
+            nonlocal call_count
+            call_count += 1
+            if includeResponses:
+                return {"responses": [{"username": "u", "files": []}], "responseCount": 1}
+            if call_count >= 2:
+                return {"fileCount": 5, "responseCount": 1, "isComplete": True}
+            return {"fileCount": 0, "responseCount": 0, "isComplete": False}
+
+        client.client.searches.state = MagicMock(side_effect=state_side_effect)
+        client.client.searches.delete = MagicMock()
+
+        results = await client._search_inner("test query", timeout_secs=10, response_limit=100)
+        assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_search_stabilizes(self, client):
+        """Search stops when file count stabilizes."""
+        client.client.searches.get_all = MagicMock(return_value=[])
+        client.client.searches.search_text = MagicMock(return_value={"id": "search-2"})
+
+        call_count = 0
+
+        def state_side_effect(id, includeResponses=False):
+            nonlocal call_count
+            call_count += 1
+            if includeResponses:
+                return {"responses": [{"username": "u"}], "responseCount": 1}
+            # Always return same count to trigger stabilization
+            return {"fileCount": 10, "responseCount": 2, "isComplete": False}
+
+        client.client.searches.state = MagicMock(side_effect=state_side_effect)
+        client.client.searches.delete = MagicMock()
+
+        results = await client._search_inner("test", timeout_secs=15, response_limit=100)
+        assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_search_falls_back_to_search_responses(self, client):
+        """When state(includeResponses) is empty, falls back to search_responses."""
+        client.client.searches.get_all = MagicMock(return_value=[])
+        client.client.searches.search_text = MagicMock(return_value={"id": "search-3"})
+
+        def state_side_effect(id, includeResponses=False):
+            if includeResponses:
+                return {"responses": [], "responseCount": 5, "fileCount": 10}
+            return {"fileCount": 10, "responseCount": 5, "isComplete": True}
+
+        client.client.searches.state = MagicMock(side_effect=state_side_effect)
+        client.client.searches.search_responses = MagicMock(return_value=[{"username": "u"}])
+        client.client.searches.delete = MagicMock()
+
+        results = await client._search_inner("test", timeout_secs=10, response_limit=100)
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_cleanup_stale_searches(self, client):
+        """Stale searches are cleaned up before new search."""
+        client.client.searches.get_all = MagicMock(return_value=[
+            {"id": "old-1"}, {"id": "old-2"},
+        ])
+        client.client.searches.delete = MagicMock()
+        client.client.searches.search_text = MagicMock(return_value={"id": "new-1"})
+
+        def state_side_effect(id, includeResponses=False):
+            if includeResponses:
+                return {"responses": [], "responseCount": 0}
+            return {"fileCount": 0, "responseCount": 0, "isComplete": True}
+
+        client.client.searches.state = MagicMock(side_effect=state_side_effect)
+
+        await client._search_inner("test", timeout_secs=5, response_limit=100)
+        # Should have deleted old-1 and old-2 plus the new search
+        assert client.client.searches.delete.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_cleanup_stale_exception_ignored(self, client):
+        """Exceptions during cleanup are silently ignored."""
+        client.client.searches.get_all = MagicMock(side_effect=Exception("network"))
+        client.client.searches.search_text = MagicMock(return_value={"id": "s1"})
+
+        def state_side_effect(id, includeResponses=False):
+            if includeResponses:
+                return {"responses": [], "responseCount": 0}
+            return {"fileCount": 0, "responseCount": 0, "isComplete": True}
+
+        client.client.searches.state = MagicMock(side_effect=state_side_effect)
+        client.client.searches.delete = MagicMock()
+
+        results = await client._search_inner("test", timeout_secs=5, response_limit=100)
+        assert isinstance(results, list)
+
+
+class TestStopAndCollect:
+    @pytest.fixture
+    def client(self):
+        with patch("slskd_api.SlskdClient") as mock_cls:
+            c = SlskdClient("http://localhost:5030", "test-key")
+            c.client = mock_cls.return_value
+            return c
+
+    @pytest.mark.asyncio
+    async def test_stop_and_collect_with_responses(self, client):
+        client.client.searches.stop = MagicMock()
+        client.client.searches.state = MagicMock(return_value={
+            "responses": [{"username": "u1"}, {"username": "u2"}],
+            "responseCount": 2,
+        })
+        client.client.searches.delete = MagicMock()
+
+        results = await client._stop_and_collect("search-1")
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_stop_and_collect_fallback(self, client):
+        client.client.searches.stop = MagicMock()
+        client.client.searches.state = MagicMock(return_value={
+            "responses": [],
+            "responseCount": 3,
+        })
+        client.client.searches.search_responses = MagicMock(return_value=[{"username": "u"}])
+        client.client.searches.delete = MagicMock()
+
+        results = await client._stop_and_collect("search-1")
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_and_collect_exception(self, client):
+        client.client.searches.stop = MagicMock()
+        client.client.searches.state = MagicMock(side_effect=Exception("fail"))
+        client.client.searches.delete = MagicMock()
+
+        results = await client._stop_and_collect("search-1")
+        assert results == []

--- a/tests/test_spotify_extended.py
+++ b/tests/test_spotify_extended.py
@@ -1,0 +1,123 @@
+"""Extended tests for Spotify metadata resolver - covering SpotifyResolver class."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from music_downloader.metadata.spotify import SpotifyResolver, TrackInfo
+
+
+class TestSpotifyResolver:
+    @pytest.fixture
+    def resolver(self):
+        with patch("music_downloader.metadata.spotify.SpotifyClientCredentials"):
+            with patch("music_downloader.metadata.spotify.spotipy.Spotify") as mock_sp:
+                r = SpotifyResolver("test-id", "test-secret")
+                r.sp = mock_sp.return_value
+                return r
+
+    def test_search_returns_track(self, resolver):
+        resolver.sp.search.return_value = {
+            "tracks": {
+                "items": [
+                    {
+                        "artists": [{"name": "Nancy Sinatra"}],
+                        "name": "Bang Bang",
+                        "album": {
+                            "name": "How Does That Grab You?",
+                            "release_date": "1966-01-01",
+                            "images": [],
+                        },
+                        "duration_ms": 162000,
+                        "external_urls": {"spotify": "https://open.spotify.com/track/xxx"},
+                    }
+                ]
+            }
+        }
+        result = resolver.search("Nancy Sinatra Bang Bang")
+        assert result is not None
+        assert result.artist == "Nancy Sinatra"
+        assert result.title == "Bang Bang"
+        assert result.year == "1966"
+
+    def test_search_no_results(self, resolver):
+        resolver.sp.search.return_value = {"tracks": {"items": []}}
+        result = resolver.search("nonexistent song xyz")
+        assert result is None
+
+    def test_search_exception(self, resolver):
+        resolver.sp.search.side_effect = Exception("API error")
+        result = resolver.search("test")
+        assert result is None
+
+    def test_search_multiple_returns_list(self, resolver):
+        resolver.sp.search.return_value = {
+            "tracks": {
+                "items": [
+                    {
+                        "artists": [{"name": "Artist1"}],
+                        "name": "Song1",
+                        "album": {"name": "Album1", "release_date": "2024-01-01", "images": []},
+                        "duration_ms": 180000,
+                        "external_urls": {"spotify": "https://open.spotify.com/track/1"},
+                    },
+                    {
+                        "artists": [{"name": "Artist2"}],
+                        "name": "Song2",
+                        "album": {"name": "Album2", "release_date": "2023-06-15", "images": []},
+                        "duration_ms": 200000,
+                        "external_urls": {"spotify": "https://open.spotify.com/track/2"},
+                    },
+                ]
+            }
+        }
+        results = resolver.search_multiple("test", limit=5)
+        assert len(results) == 2
+        assert results[0].artist == "Artist1"
+        assert results[1].artist == "Artist2"
+
+    def test_search_multiple_empty(self, resolver):
+        resolver.sp.search.return_value = {"tracks": {"items": []}}
+        results = resolver.search_multiple("nonexistent")
+        assert results == []
+
+    def test_search_multiple_exception(self, resolver):
+        resolver.sp.search.side_effect = Exception("API error")
+        results = resolver.search_multiple("test")
+        assert results == []
+
+    def test_search_missing_spotify_url(self, resolver):
+        resolver.sp.search.return_value = {
+            "tracks": {
+                "items": [
+                    {
+                        "artists": [{"name": "Artist"}],
+                        "name": "Song",
+                        "album": {"name": "Album", "release_date": "2024"},
+                        "duration_ms": 180000,
+                        "external_urls": {},
+                    }
+                ]
+            }
+        }
+        result = resolver.search("test")
+        assert result is not None
+        assert result.spotify_url == ""
+
+    def test_search_missing_release_date(self, resolver):
+        resolver.sp.search.return_value = {
+            "tracks": {
+                "items": [
+                    {
+                        "artists": [{"name": "Artist"}],
+                        "name": "Song",
+                        "album": {"name": "Album"},
+                        "duration_ms": 180000,
+                        "external_urls": {"spotify": "url"},
+                    }
+                ]
+            }
+        }
+        result = resolver.search("test")
+        assert result is not None
+        assert result.year == ""

--- a/tests/test_spotify_extended.py
+++ b/tests/test_spotify_extended.py
@@ -1,20 +1,22 @@
 """Extended tests for Spotify metadata resolver - covering SpotifyResolver class."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from music_downloader.metadata.spotify import SpotifyResolver, TrackInfo
+from music_downloader.metadata.spotify import SpotifyResolver
 
 
 class TestSpotifyResolver:
     @pytest.fixture
     def resolver(self):
-        with patch("music_downloader.metadata.spotify.SpotifyClientCredentials"):
-            with patch("music_downloader.metadata.spotify.spotipy.Spotify") as mock_sp:
-                r = SpotifyResolver("test-id", "test-secret")
-                r.sp = mock_sp.return_value
-                return r
+        with (
+            patch("music_downloader.metadata.spotify.SpotifyClientCredentials"),
+            patch("music_downloader.metadata.spotify.spotipy.Spotify") as mock_sp,
+        ):
+            r = SpotifyResolver("test-id", "test-secret")
+            r.sp = mock_sp.return_value
+            return r
 
     def test_search_returns_track(self, resolver):
         resolver.sp.search.return_value = {


### PR DESCRIPTION
## Summary
- Adds 12 new test files with 258 new tests (321 total, up from 63)
- Improves overall test coverage from 32% to 93%
- All modules now at 90%+ coverage: config (100%), keyboards (100%), spotify (100%), embed_artwork (100%), slskd_client (95%), handlers (93%), file_handler (91%), flac_analyzer (93%), artwork_embedder (90%), scorer (90%), __main__ (91%)
- Uses mocks for Telegram Bot API, slskd API, Spotify API, and filesystem operations

## Test plan
- [x] All 321 tests pass locally
- [x] Coverage verified at 93% via pytest-cov
- [ ] CI pipeline passes