### PR TITLE
fix: use importlib.metadata for single-source version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching
-COPY requirements.txt .
+COPY requirements.txt pyproject.toml ./
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
@@ -19,6 +19,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY src/ ./src/
 COPY scripts/ ./scripts/
+
+# Install package for metadata (version)
+RUN pip install --no-cache-dir --no-deps .
 
 # Create non-root user for security
 RUN useradd -m -u 1000 slskdimporter && \
@@ -31,7 +34,6 @@ USER slskdimporter
 
 # Set default environment variables
 ENV LOG_LEVEL=INFO \
-    PYTHONPATH=/app/src \
     HEALTH_PORT=8080
 
 # Health check

--- a/src/music_downloader/__init__.py
+++ b/src/music_downloader/__init__.py
@@ -1,3 +1,8 @@
 """telegram-slskd-local-bot - Automated music discovery and download via Telegram bot."""
 
-__version__ = "0.7.1"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("telegram-slskd-local-bot")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"


### PR DESCRIPTION
## Summary
- Remove hardcoded `__version__ = "0.7.1"` from `__init__.py` that was out of sync with pyproject.toml (`0.10.0`)
- Use `importlib.metadata.version()` to derive version at runtime from installed package metadata
- Install package in Dockerfile (`pip install --no-deps .`) so metadata is available in container
- Remove `PYTHONPATH` env var hack (package is properly installed now)

## Test plan
- [x] 418 tests pass locally
- [ ] CI passes
- [ ] Docker build succeeds and `docker logs` shows correct version