### PR TITLE
fix: resolve 4 ruff lint errors blocking CI

### DIFF
--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -558,9 +558,7 @@ class MusicBot:
                 if query_artist and query_artist not in artist_lower:
                     continue
                 artist_words = set(artist_lower.split())
-                if len(artist_words) >= 2 and artist_lower in query_lower:
-                    artist_match_tracks.append(t)
-                elif artist_words.issubset(query_words):
+                if (len(artist_words) >= 2 and artist_lower in query_lower) or artist_words.issubset(query_words):
                     artist_match_tracks.append(t)
                 else:
                     other_tracks.append(t)
@@ -1290,9 +1288,9 @@ class MusicBot:
         self._awaiting_direct_metadata[chat_id] = search_query
 
         await query.edit_message_text(
-            f"\U0001f3b5 How should this track be saved?\n\n"
-            f"Send the name as: `Artist - Title`\n"
-            f"(This will be used for the filename and tags)",
+            "\U0001f3b5 How should this track be saved?\n\n"
+            "Send the name as: `Artist - Title`\n"
+            "(This will be used for the filename and tags)",
             parse_mode=ParseMode.MARKDOWN,
         )
 


### PR DESCRIPTION
## Summary
The `Lint` CI job (`ruff check .`) has been failing on every commit since ~May 25 due to 4 pre-existing lint errors. This fixes all of them with real code fixes (no rule disabling, no blanket noqa).

## Fixes
- **SIM114** (`handlers.py:561`): combined two identical `if`/`elif` branches that both appended to `artist_match_tracks` into a single condition with `or`. Added explicit parentheses to keep operator precedence unambiguous; semantics are identical to the original.
- **F541** (`handlers.py:1293-1295`): removed extraneous `f` prefixes from three implicitly-concatenated string literals that contained no placeholders.

## Verification
- `ruff check .` -> All checks passed!
- `ruff format --check .` -> 44 files already formatted