### PR TITLE
security: block fork PRs from running on the self-hosted runner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,11 @@ jobs:
   analyze:
     name: Analyze
     runs-on: [self-hosted, Linux, X64]
+    # Never run untrusted fork PR code on the self-hosted runner.
+    # Same-repo branches, push, and schedule still run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,13 @@ on:
 jobs:
   ruff:
     runs-on: [self-hosted, Linux, X64]
+    # Never run untrusted fork PR code on the self-hosted runner.
+    # Same-repo branches, push, schedule, and workflow_dispatch still run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,13 @@ on:
 jobs:
   test:
     runs-on: [self-hosted, Linux, X64]
+    # Never run untrusted fork PR code on the self-hosted runner.
+    # Same-repo branches, push, schedule, and workflow_dispatch still run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Adds an `if:` guard so the `pull_request`-triggered CI jobs (test, lint, CodeQL) run on the self-hosted runner **only for same-repo events**, never for PRs from forks.

## Why
On a **public** repo, a job that triggers on `pull_request` and runs on a self-hosted runner lets anyone's fork PR execute attacker-controlled code (`pip install -e`, `pytest`, build steps) directly on the runner host. That host also runs other production services and runners, so the blast radius is large.

The guard keeps the runner self-hosted (build cache, host iGPU, no hosted-minute usage) for all trusted runs — push, schedule, workflow_dispatch, and PRs from branches within this repo — while fork PRs are skipped. This is the same pattern already used in `tailscale-rs` and `Telegram-Archive`.

```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

Also adds explicit `permissions: contents: read` (CodeQL keeps `security-events: write`).

## What stays unchanged
`docker-publish.yml`, `release.yml`, `dockerhub-description.yml`, `stale.yml` only trigger on push-to-main/tag, `workflow_dispatch`, or `schedule` — a fork PR cannot trigger them, so no guard is needed.

## Test plan
- [x] YAML validates
- [x] Jobs still run on self-hosted for same-repo pushes/PRs (this PR is from a same-repo branch, so CI runs)