### PR TITLE
ci: use GitHub-hosted ubuntu-latest runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,12 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: [self-hosted, Linux, X64]
-    # Never run untrusted fork PR code on the self-hosted runner.
-    # Same-repo branches, push, and schedule still run.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-description:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,7 @@ on:
 
 jobs:
   ruff:
-    runs-on: [self-hosted, Linux, X64]
-    # Never run untrusted fork PR code on the self-hosted runner.
-    # Same-repo branches, push, schedule, and workflow_dispatch still run.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     permissions:
       contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     name: Create GitHub Release
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     env:
       PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64]
-    # Never run untrusted fork PR code on the self-hosted runner.
-    # Same-repo branches, push, schedule, and workflow_dispatch still run.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
Switches self-hosted Linux CI jobs to GitHub-hosted `ubuntu-latest`.

## Why
GitHub-hosted standard runners are **free and unlimited on public repos**. Moving CI off the home-lab self-hosted runners:
- frees my servers from CI load,
- runs PR code in throwaway isolated VMs (removes the fork-PR attack surface entirely),
- costs $0 on public repos.

The earlier self-hosted fork-guard `if:` is removed (no longer needed on hosted runners). Any macOS/Windows self-hosted jobs (desktop builds) are left unchanged.
