### PR TITLE
fix: survive hung slskd, restarts, and read-only mounts without losing work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,10 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
 
     volumes:
-      # Mount slskd completed downloads directory (read-only)
+      # Mount slskd completed downloads directory (read-write: the bot
+      # deletes rejected/cleaned-up files from here after processing)
       # Adjust the host path to match your slskd downloads location
-      - ${SLSKD_DOWNLOAD_PATH:-./downloads}:/downloads:ro
+      - ${SLSKD_DOWNLOAD_PATH:-./downloads}:/downloads
 
       # Mount output music directory (read-write)
       # This is where renamed FLAC files are placed

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -8,10 +8,11 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
+from uuid import uuid4
 
 from telegram import Message, Update
 from telegram.constants import ParseMode
-from telegram.error import BadRequest, NetworkError, TimedOut
+from telegram.error import BadRequest, NetworkError, RetryAfter, TimedOut
 from telegram.ext import (
     Application,
     CallbackQueryHandler,
@@ -71,36 +72,56 @@ def _escape_md(text: str) -> str:
 async def _safe_edit(msg: Message, text: str, **kwargs) -> bool:
     """Edit a Telegram message, swallowing common failures.
 
+    Waits out flood control (RetryAfter) once before giving up.
     Returns True on success, False if the edit failed (logged as warning).
     """
-    try:
-        await msg.edit_text(text, **kwargs)
-        return True
-    except BadRequest as exc:
-        logger.warning(f"Telegram edit failed (BadRequest): {exc}")
-        return False
-    except TimedOut:
-        logger.warning("Telegram edit timed out")
-        return False
-    except NetworkError as exc:
-        logger.warning(f"Telegram edit network error: {exc}")
-        return False
+    for attempt in (1, 2):
+        try:
+            await msg.edit_text(text, **kwargs)
+            return True
+        except RetryAfter as exc:
+            if attempt == 2:
+                logger.warning(f"Telegram edit still flood-limited after waiting: {exc}")
+                return False
+            logger.warning(f"Telegram flood control on edit, retrying in {exc.retry_after}s")
+            await asyncio.sleep(exc.retry_after + 0.5)
+        except BadRequest as exc:
+            logger.warning(f"Telegram edit failed (BadRequest): {exc}")
+            return False
+        except TimedOut:
+            logger.warning("Telegram edit timed out")
+            return False
+        except NetworkError as exc:
+            logger.warning(f"Telegram edit network error: {exc}")
+            return False
+    return False
 
 
 async def _safe_query_edit(query, text: str, **kwargs) -> bool:
-    """Edit a callback query message, swallowing transient Telegram errors."""
-    try:
-        await query.edit_message_text(text, **kwargs)
-        return True
-    except BadRequest as exc:
-        logger.warning(f"Telegram query edit failed (BadRequest): {exc}")
-        return False
-    except TimedOut:
-        logger.warning("Telegram query edit timed out")
-        return False
-    except NetworkError as exc:
-        logger.warning(f"Telegram query edit network error: {exc}")
-        return False
+    """Edit a callback query message, swallowing transient Telegram errors.
+
+    Waits out flood control (RetryAfter) once before giving up.
+    """
+    for attempt in (1, 2):
+        try:
+            await query.edit_message_text(text, **kwargs)
+            return True
+        except RetryAfter as exc:
+            if attempt == 2:
+                logger.warning(f"Telegram query edit still flood-limited after waiting: {exc}")
+                return False
+            logger.warning(f"Telegram flood control on query edit, retrying in {exc.retry_after}s")
+            await asyncio.sleep(exc.retry_after + 0.5)
+        except BadRequest as exc:
+            logger.warning(f"Telegram query edit failed (BadRequest): {exc}")
+            return False
+        except TimedOut:
+            logger.warning("Telegram query edit timed out")
+            return False
+        except NetworkError as exc:
+            logger.warning(f"Telegram query edit network error: {exc}")
+            return False
+    return False
 
 
 # Noise keywords that Spotify appends to track titles but Soulseek users never use.
@@ -237,6 +258,9 @@ class PendingSearch:
     message_id: int | None = None
     is_fallback: bool = False
     page: int = 0
+    # Unique id binding result keyboards to this search; stale buttons from an
+    # earlier search must never resolve against a newer result list.
+    search_id: str = ""
 
 
 @dataclass
@@ -250,6 +274,7 @@ class PendingDownload:
     status_message_id: int | None = None
     approval_message_id: int | None = None  # Message with approve/reject buttons
     result_index: int = 0  # Position in ranked results list
+    search_id: str = ""  # Search this download came from (see PendingSearch)
 
 
 class MusicBot:
@@ -273,10 +298,9 @@ class MusicBot:
         # Per-user pending searches (chat_id -> PendingSearch)
         self.pending: dict[int, PendingSearch] = {}
 
-        # Active downloads keyed by short numeric ID
+        # Active downloads keyed by short unique ID
         # download_id -> PendingDownload
         self.downloads: dict[str, PendingDownload] = {}
-        self._dl_counter = 0
 
         # Per-chat Spotify candidates when multiple tracks match (chat_id -> list[TrackInfo])
         self._spotify_candidates: dict[int, list[TrackInfo]] = {}
@@ -306,6 +330,12 @@ class MusicBot:
         # Separate pending search state for import flows (avoids clobbering self.pending)
         self._import_pending: dict[int, PendingSearch] = {}
 
+        # A restart cannot leave a genuinely running import behind, but it does
+        # leave pending/active rows that would block /import for that chat forever.
+        stale_jobs = self.import_repo.cancel_stale_jobs()
+        if stale_jobs:
+            logger.warning("Cancelled %d stale import job(s) left over from a previous run", stale_jobs)
+
     def _is_authorized(self, user_id: int) -> bool:
         """Check if a user is authorized to use the bot (fail-closed)."""
         if not self.config.telegram_allowed_users:
@@ -314,10 +344,15 @@ class MusicBot:
 
     async def _check_auth(self, update: Update) -> bool:
         """Check authorization and send a message if denied."""
-        if not self._is_authorized(update.effective_user.id):
-            await update.message.reply_text("You are not authorized to use this bot.")
-            return False
-        return True
+        user = update.effective_user
+        if user is not None and self._is_authorized(user.id):
+            return True
+        message = update.effective_message
+        if message is not None and user is not None:
+            # Include the numeric ID so a self-hoster can copy it straight
+            # into TELEGRAM_ALLOWED_USERS instead of hunting for it.
+            await message.reply_text(f"You are not authorized to use this bot.\nYour Telegram user ID: {user.id}")
+        return False
 
     # =========================================================================
     # CANCELLATION
@@ -413,16 +448,24 @@ class MusicBot:
         if not await self._check_auth(update):
             return
 
+        chat_id = update.effective_chat.id
         lines = []
 
-        if self.pending:
+        # Only this chat's activity: /status must not leak other users' work.
+        chat_searches = [p for cid, p in self.pending.items() if cid == chat_id]
+        if chat_searches:
             lines.append("*Active searches:*\n")
-            for _chat_id, pending in self.pending.items():
-                lines.append(f"• {pending.track.artist} - {pending.track.title}")
+            for pending in chat_searches:
+                if pending.track:
+                    lines.append(f"• {pending.track.artist} - {pending.track.title}")
+                else:
+                    # Search still resolving on Spotify (or awaiting a pick)
+                    lines.append(f"• `{pending.query}`")
 
-        if self.downloads:
+        chat_downloads = [d for d in self.downloads.values() if d.chat_id == chat_id]
+        if chat_downloads:
             lines.append("\n*Active downloads:*\n")
-            for _dl_id, dl in self.downloads.items():
+            for dl in chat_downloads:
                 lines.append(f"• {dl.track.artist} - {dl.track.title} ({dl.result.basename})")
 
         if not lines:
@@ -706,12 +749,14 @@ class MusicBot:
                 )
                 return
 
+            search_id = uuid4().hex[:8]
             self.pending[chat_id] = PendingSearch(
                 query=f"{track.artist} {track.title}",
                 track=track,
                 results=ranked,
                 message_id=searching_msg.message_id,
                 is_fallback=is_fallback,
+                search_id=search_id,
             )
 
             results_text = self._format_results(track, ranked, is_fallback, page=0, page_size=self.config.max_results)
@@ -719,7 +764,9 @@ class MusicBot:
                 searching_msg,
                 results_text,
                 parse_mode=ParseMode.MARKDOWN,
-                reply_markup=build_results_keyboard(ranked, page=0, page_size=self.config.max_results),
+                reply_markup=build_results_keyboard(
+                    ranked, page=0, page_size=self.config.max_results, search_id=search_id
+                ),
             )
 
         except Exception:
@@ -853,6 +900,14 @@ class MusicBot:
         generation = self._chat_generation.get(chat_id, 0)
         await self._do_slskd_search(context, chat_id, track, searching_msg, generation)
 
+    @staticmethod
+    def _split_search_callback(data: str) -> tuple[str, str]:
+        """Split ``dl:<search_id>:<action>`` (or legacy ``dl:<action>``) into (search_id, action)."""
+        parts = data.split(":", 2)
+        if len(parts) == 3:
+            return parts[1], parts[2]
+        return "", parts[1]
+
     async def _handle_results_page(self, update, context, chat_id: int, data: str):
         """Handle slskd results page navigation (◀️ / ▶️)."""
         query = update.callback_query
@@ -861,8 +916,13 @@ class MusicBot:
             await query.edit_message_text("Search expired. Send a new query.")
             return
 
+        search_id, action = self._split_search_callback(data)
+        if search_id != pending.search_id:
+            await query.edit_message_text("⌛ These results are out of date. Send a new search.")
+            return
+
         try:
-            page = int(data.split(":", 1)[1])
+            page = int(action)
         except ValueError:
             return
 
@@ -877,7 +937,9 @@ class MusicBot:
         await query.edit_message_text(
             results_text,
             parse_mode=ParseMode.MARKDOWN,
-            reply_markup=build_results_keyboard(pending.results, page=page, page_size=self.config.max_results),
+            reply_markup=build_results_keyboard(
+                pending.results, page=page, page_size=self.config.max_results, search_id=pending.search_id
+            ),
         )
 
     async def _handle_download_selection(self, update, context, chat_id: int, data: str):
@@ -888,7 +950,12 @@ class MusicBot:
             await query.edit_message_text("Search expired. Send a new query.")
             return
 
-        action = data.split(":", 1)[1]
+        search_id, action = self._split_search_callback(data)
+        if search_id != pending.search_id:
+            # Button belongs to an older search; acting on it would download
+            # from the CURRENT result list under the old labels.
+            await query.edit_message_text("⌛ These results are out of date. Send a new search.")
+            return
 
         if action == "cancel":
             del self.pending[chat_id]
@@ -904,6 +971,7 @@ class MusicBot:
                 return
 
         if index >= len(pending.results):
+            await query.edit_message_text("⌛ These results are out of date. Send a new search.")
             return
 
         result = pending.results[index]
@@ -921,7 +989,7 @@ class MusicBot:
         )
 
         task = context.application.create_task(
-            self._do_download(context, chat_id, track, result, status_msg, index),
+            self._do_download(context, chat_id, track, result, status_msg, index, pending.search_id),
             update=update,
         )
         self._track_task(chat_id, task)
@@ -944,23 +1012,34 @@ class MusicBot:
     # =========================================================================
 
     def _next_dl_id(self) -> str:
-        """Generate a short unique download ID."""
-        self._dl_counter += 1
-        return str(self._dl_counter)
+        """Generate a short unique download ID.
+
+        Random rather than sequential: sequential IDs restart at 1 after a
+        restart, so a stale approve/reject button embedded in an old Telegram
+        message would act on an unrelated new download.
+        """
+        return uuid4().hex[:8]
 
     def _has_next_result(self, chat_id: int, current_index: int) -> bool:
         pending = self.pending.get(chat_id)
         return pending is not None and current_index + 1 < len(pending.results)
 
     async def _do_download(
-        self, context, chat_id: int, track: TrackInfo, result: SearchResult, status_msg, result_index: int = 0
+        self,
+        context,
+        chat_id: int,
+        track: TrackInfo,
+        result: SearchResult,
+        status_msg,
+        result_index: int = 0,
+        search_id: str = "",
     ):
         """Download a file, send it to Telegram for preview, and ask for approval."""
         dl_id = self._next_dl_id()
         label = f"#{result_index + 1}"
 
         try:
-            success = self.slskd.enqueue_download(result)
+            success = await asyncio.to_thread(self.slskd.enqueue_download, result)
             if not success:
                 pending_dl = PendingDownload(
                     track=track,
@@ -968,6 +1047,7 @@ class MusicBot:
                     chat_id=chat_id,
                     status_message_id=status_msg.message_id,
                     result_index=result_index,
+                    search_id=search_id,
                 )
                 self.downloads[dl_id] = pending_dl
                 has_next = self._has_next_result(chat_id, result_index)
@@ -992,6 +1072,7 @@ class MusicBot:
                     chat_id=chat_id,
                     status_message_id=status_msg.message_id,
                     result_index=result_index,
+                    search_id=search_id,
                 )
                 self.downloads[dl_id] = pending_dl
                 has_next = self._has_next_result(chat_id, result_index)
@@ -1020,6 +1101,7 @@ class MusicBot:
                 source_path=source_path,
                 status_message_id=status_msg.message_id,
                 result_index=result_index,
+                search_id=search_id,
             )
             self.downloads[dl_id] = pending_dl
 
@@ -1220,9 +1302,7 @@ class MusicBot:
                 await self._add_history(track, result, "file_not_found")
 
         elif action == "reject":
-            if pending_dl.source_path and os.path.isfile(pending_dl.source_path):
-                os.remove(pending_dl.source_path)
-                logger.info(f"Deleted rejected file: {pending_dl.source_path}")
+            self._remove_download_file(pending_dl.source_path)
             await self._edit_approval_message(query, f"🚫 Rejected: {track.artist} - {track.title}")
             await self._add_history(track, result, "rejected")
             logger.info(f"Rejected: {track.artist} - {track.title} ({result.basename})")
@@ -1242,8 +1322,7 @@ class MusicBot:
         stale = [(k, v) for k, v in self.downloads.items() if v.chat_id == chat_id]
         for dl_id, dl in stale:
             del self.downloads[dl_id]
-            if dl.source_path and os.path.isfile(dl.source_path):
-                os.remove(dl.source_path)
+            self._remove_download_file(dl.source_path)
             if dl.approval_message_id:
                 try:
                     await context.bot.edit_message_caption(
@@ -1261,6 +1340,22 @@ class MusicBot:
 
         for task in self._active_tasks.pop(chat_id, set()):
             task.cancel()
+
+    @staticmethod
+    def _remove_download_file(path: str | None) -> None:
+        """Delete a file from the downloads dir, never letting failure break the flow.
+
+        The downloads volume may be mounted read-only; a failed delete must not
+        swallow the reject/dismiss handling around it.
+        """
+        if not path:
+            return
+        try:
+            if os.path.isfile(path):
+                os.remove(path)
+                logger.info(f"Deleted file from downloads: {path}")
+        except OSError as exc:
+            logger.warning("Could not delete %s (downloads mount read-only?): %s", path, exc)
 
     @staticmethod
     async def _edit_approval_message(query, text: str):
@@ -1337,12 +1432,14 @@ class MusicBot:
                 )
                 return
 
+            search_id = uuid4().hex[:8]
             self.pending[chat_id] = PendingSearch(
                 query=query,
                 track=synthetic_track,
                 results=ranked,
                 message_id=searching_msg.message_id,
                 is_fallback=is_fallback,
+                search_id=search_id,
             )
 
             results_text = self._format_results(
@@ -1352,7 +1449,9 @@ class MusicBot:
                 searching_msg,
                 results_text,
                 parse_mode=ParseMode.MARKDOWN,
-                reply_markup=build_results_keyboard(ranked, page=0, page_size=self.config.max_results),
+                reply_markup=build_results_keyboard(
+                    ranked, page=0, page_size=self.config.max_results, search_id=search_id
+                ),
             )
 
         except Exception:
@@ -1446,8 +1545,15 @@ class MusicBot:
 
         chat_id = update.effective_chat.id
 
-        # Cancel import if active
+        # Cancel import if active. Fall back to the DB when the in-memory map
+        # is empty (abandoned confirm screen, or state lost to a restart) —
+        # otherwise the pending/active row blocks /import forever while this
+        # very command reports "Nothing to cancel."
         job_id = self._active_import.pop(chat_id, None)
+        if job_id is None:
+            active = await asyncio.to_thread(self.import_repo.get_active_job, chat_id)
+            if active is not None:
+                job_id = active.id
         if job_id:
             await asyncio.to_thread(self.import_repo.update_job_status, job_id, JobStatus.cancelled)
             self._cancel_chat_operations(chat_id)
@@ -1644,12 +1750,14 @@ class MusicBot:
             best = ranked[0]
 
             # Store results for potential "next result" retry (separate from regular search)
+            search_id = uuid4().hex[:8]
             self._import_pending[chat_id] = PendingSearch(
                 query=search_query,
                 track=track,
                 results=ranked,
                 message_id=searching_msg.message_id,
                 is_fallback=is_fallback,
+                search_id=search_id,
             )
 
             dl_id = self._next_dl_id()
@@ -1659,6 +1767,7 @@ class MusicBot:
                 chat_id=chat_id,
                 source_path=None,
                 status_message_id=searching_msg.message_id,
+                search_id=search_id,
             )
             self.downloads[dl_id] = pending_dl
 
@@ -1701,7 +1810,7 @@ class MusicBot:
     ):
         """Download a file within an import flow."""
         try:
-            success = self.slskd.enqueue_download(result)
+            success = await asyncio.to_thread(self.slskd.enqueue_download, result)
             if not success:
                 await _safe_edit(
                     status_msg,
@@ -1829,7 +1938,7 @@ class MusicBot:
         )
 
         task = context.application.create_task(
-            self._do_download(context, chat_id, track, result, status_msg, result_index),
+            self._do_download(context, chat_id, track, result, status_msg, result_index, pending_dl.search_id),
             update=update,
         )
         self._track_task(chat_id, task)
@@ -1848,6 +1957,12 @@ class MusicBot:
 
         if pending_dl.chat_id != chat_id:
             self.downloads[dl_id] = pending_dl
+            return
+
+        if pending.search_id != pending_dl.search_id:
+            # The failed download belongs to an older search; indexing into the
+            # current result list would fetch an unrelated file.
+            await _safe_query_edit(query, "⏹ No more results available. Try a new search.")
             return
 
         next_idx = pending_dl.result_index + 1
@@ -1871,7 +1986,7 @@ class MusicBot:
         )
 
         task = context.application.create_task(
-            self._do_download(context, chat_id, track, next_result, status_msg, next_idx),
+            self._do_download(context, chat_id, track, next_result, status_msg, next_idx, pending.search_id),
             update=update,
         )
         self._track_task(chat_id, task)
@@ -2021,6 +2136,18 @@ class MusicBot:
             return words[0].title(), words[1].title()
         return "", query.title()
 
+    async def on_error(self, update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Global error handler: log the crash and tell the user something broke.
+
+        Without this, python-telegram-bot logs one line and the user sees
+        nothing at all — a crashed command is indistinguishable from a dead bot.
+        """
+        logger.error("Unhandled error while processing update", exc_info=context.error)
+        message = update.effective_message if isinstance(update, Update) else None
+        if message is not None:
+            with contextlib.suppress(Exception):
+                await message.reply_text("⚠️ Something went wrong. Please try again.")
+
     async def _add_history(self, track: TrackInfo, result: SearchResult, status: str):
         """Add an entry to download history (persisted in SQLite)."""
         await asyncio.to_thread(
@@ -2051,20 +2178,27 @@ def create_bot(config: Config) -> Application:
 
     app = Application.builder().token(config.telegram_bot_token).build()
 
+    # Only react to NEW messages: an edited message arrives with
+    # update.message=None and would crash every handler that replies.
+    new_messages = filters.UpdateType.MESSAGE
+
     # Command handlers
-    app.add_handler(CommandHandler("start", bot.cmd_start))
-    app.add_handler(CommandHandler("help", bot.cmd_help))
-    app.add_handler(CommandHandler("auto", bot.cmd_auto))
-    app.add_handler(CommandHandler("status", bot.cmd_status))
-    app.add_handler(CommandHandler("history", bot.cmd_history))
-    app.add_handler(CommandHandler("import", bot.cmd_import))
-    app.add_handler(CommandHandler("cancel", bot.cmd_cancel))
+    app.add_handler(CommandHandler("start", bot.cmd_start, filters=new_messages))
+    app.add_handler(CommandHandler("help", bot.cmd_help, filters=new_messages))
+    app.add_handler(CommandHandler("auto", bot.cmd_auto, filters=new_messages))
+    app.add_handler(CommandHandler("status", bot.cmd_status, filters=new_messages))
+    app.add_handler(CommandHandler("history", bot.cmd_history, filters=new_messages))
+    app.add_handler(CommandHandler("import", bot.cmd_import, filters=new_messages))
+    app.add_handler(CommandHandler("cancel", bot.cmd_cancel, filters=new_messages))
 
     # Callback query handler (inline keyboard buttons)
     app.add_handler(CallbackQueryHandler(bot.handle_callback))
 
     # Text message handler (song search) — must be last
-    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, bot.handle_text))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND & new_messages, bot.handle_text))
+
+    # Surface crashes to the operator and the user instead of swallowing them
+    app.add_error_handler(bot.on_error)
 
     logger.info("Telegram bot configured")
     return app

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -4,6 +4,7 @@ Telegram bot handlers for music search and download.
 
 import asyncio
 import contextlib
+import datetime
 import logging
 import os
 import re
@@ -69,6 +70,14 @@ def _escape_md(text: str) -> str:
     return text
 
 
+def _retry_after_seconds(exc: RetryAfter) -> float:
+    """RetryAfter.retry_after is an int today and a timedelta under PTB_TIMEDELTA."""
+    value = exc.retry_after
+    if isinstance(value, datetime.timedelta):
+        return value.total_seconds()
+    return float(value)
+
+
 async def _safe_edit(msg: Message, text: str, **kwargs) -> bool:
     """Edit a Telegram message, swallowing common failures.
 
@@ -84,7 +93,7 @@ async def _safe_edit(msg: Message, text: str, **kwargs) -> bool:
                 logger.warning(f"Telegram edit still flood-limited after waiting: {exc}")
                 return False
             logger.warning(f"Telegram flood control on edit, retrying in {exc.retry_after}s")
-            await asyncio.sleep(exc.retry_after + 0.5)
+            await asyncio.sleep(_retry_after_seconds(exc) + 0.5)
         except BadRequest as exc:
             logger.warning(f"Telegram edit failed (BadRequest): {exc}")
             return False
@@ -111,7 +120,7 @@ async def _safe_query_edit(query, text: str, **kwargs) -> bool:
                 logger.warning(f"Telegram query edit still flood-limited after waiting: {exc}")
                 return False
             logger.warning(f"Telegram flood control on query edit, retrying in {exc.retry_after}s")
-            await asyncio.sleep(exc.retry_after + 0.5)
+            await asyncio.sleep(_retry_after_seconds(exc) + 0.5)
         except BadRequest as exc:
             logger.warning(f"Telegram query edit failed (BadRequest): {exc}")
             return False
@@ -457,16 +466,18 @@ class MusicBot:
             lines.append("*Active searches:*\n")
             for pending in chat_searches:
                 if pending.track:
-                    lines.append(f"• {pending.track.artist} - {pending.track.title}")
+                    lines.append(f"• {_escape_md(pending.track.artist)} - {_escape_md(pending.track.title)}")
                 else:
                     # Search still resolving on Spotify (or awaiting a pick)
-                    lines.append(f"• `{pending.query}`")
+                    lines.append(f"• {_escape_md(pending.query)}")
 
         chat_downloads = [d for d in self.downloads.values() if d.chat_id == chat_id]
         if chat_downloads:
             lines.append("\n*Active downloads:*\n")
             for dl in chat_downloads:
-                lines.append(f"• {dl.track.artist} - {dl.track.title} ({dl.result.basename})")
+                lines.append(
+                    f"• {_escape_md(dl.track.artist)} - {_escape_md(dl.track.title)} ({_escape_md(dl.result.basename)})"
+                )
 
         if not lines:
             await update.message.reply_text("No active searches or downloads.")
@@ -918,7 +929,7 @@ class MusicBot:
 
         search_id, action = self._split_search_callback(data)
         if search_id != pending.search_id:
-            await query.edit_message_text("⌛ These results are out of date. Send a new search.")
+            await _safe_query_edit(query, "⌛ These results are out of date. Send a new search.")
             return
 
         try:
@@ -954,7 +965,7 @@ class MusicBot:
         if search_id != pending.search_id:
             # Button belongs to an older search; acting on it would download
             # from the CURRENT result list under the old labels.
-            await query.edit_message_text("⌛ These results are out of date. Send a new search.")
+            await _safe_query_edit(query, "⌛ These results are out of date. Send a new search.")
             return
 
         if action == "cancel":
@@ -971,7 +982,7 @@ class MusicBot:
                 return
 
         if index >= len(pending.results):
-            await query.edit_message_text("⌛ These results are out of date. Send a new search.")
+            await _safe_query_edit(query, "⌛ These results are out of date. Send a new search.")
             return
 
         result = pending.results[index]

--- a/src/music_downloader/bot/keyboards.py
+++ b/src/music_downloader/bot/keyboards.py
@@ -12,12 +12,15 @@ def build_results_keyboard(
     results: list[SearchResult],
     page: int = 0,
     page_size: int = 10,
+    search_id: str = "",
 ) -> InlineKeyboardMarkup:
     """
     Build an inline keyboard with search results for the user to pick from.
 
     Each button shows: duration | quality | size
-    Callback data format: dl:<index>
+    Callback data format: dl:<search_id>:<index> — the search_id binds the
+    button to the search that produced it, so a stale keyboard from an
+    earlier search can never act on the current one.
     """
     start = page * page_size
     end = min(start + page_size, len(results))
@@ -27,22 +30,22 @@ def build_results_keyboard(
     for i, result in enumerate(page_results):
         absolute_idx = start + i
         label = f"#{absolute_idx + 1} {result.duration_display} | {result.quality_display} | {result.size_mb:.0f}MB"
-        buttons.append([InlineKeyboardButton(label, callback_data=f"dl:{absolute_idx}")])
+        buttons.append([InlineKeyboardButton(label, callback_data=f"dl:{search_id}:{absolute_idx}")])
 
     # Pagination row
     nav_row = []
     if page > 0:
-        nav_row.append(InlineKeyboardButton("◀️ Prev", callback_data=f"dl_page:{page - 1}"))
+        nav_row.append(InlineKeyboardButton("◀️ Prev", callback_data=f"dl_page:{search_id}:{page - 1}"))
     if end < len(results):
-        nav_row.append(InlineKeyboardButton("Next ▶️", callback_data=f"dl_page:{page + 1}"))
+        nav_row.append(InlineKeyboardButton("Next ▶️", callback_data=f"dl_page:{search_id}:{page + 1}"))
     if nav_row:
         buttons.append(nav_row)
 
     # Action row
     action_row = []
     if results:
-        action_row.append(InlineKeyboardButton("Auto-pick best", callback_data="dl:auto"))
-    action_row.append(InlineKeyboardButton("Cancel", callback_data="dl:cancel"))
+        action_row.append(InlineKeyboardButton("Auto-pick best", callback_data=f"dl:{search_id}:auto"))
+    action_row.append(InlineKeyboardButton("Cancel", callback_data=f"dl:{search_id}:cancel"))
     buttons.append(action_row)
 
     return InlineKeyboardMarkup(buttons)

--- a/src/music_downloader/bot/keyboards.py
+++ b/src/music_downloader/bot/keyboards.py
@@ -12,7 +12,8 @@ def build_results_keyboard(
     results: list[SearchResult],
     page: int = 0,
     page_size: int = 10,
-    search_id: str = "",
+    *,
+    search_id: str,
 ) -> InlineKeyboardMarkup:
     """
     Build an inline keyboard with search results for the user to pick from.

--- a/src/music_downloader/config.py
+++ b/src/music_downloader/config.py
@@ -58,8 +58,9 @@ class Config:
         # Auto-download best match without user confirmation
         self.auto_mode = os.getenv("AUTO_MODE", "false").lower() == "true"
 
-        # Maximum number of search results to show per page
-        self.max_results = int(os.getenv("MAX_RESULTS", "10"))
+        # Maximum number of search results to show per page (floor of 1 —
+        # a zero would divide by zero in results pagination)
+        self.max_results = max(1, int(os.getenv("MAX_RESULTS", "10")))
 
         # Duration tolerance in seconds when matching Spotify duration
         self.duration_tolerance_secs = int(os.getenv("DURATION_TOLERANCE_SECS", "5"))

--- a/src/music_downloader/persistence/database.py
+++ b/src/music_downloader/persistence/database.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sqlite3
 import time
+import uuid
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ CREATE INDEX IF NOT EXISTS idx_download_history_created ON download_history(crea
 # locked database) is a SUBCLASS of DatabaseError. Only genuine file
 # corruption justifies replacing the database; everything else must
 # propagate so a transient condition can't destroy history.
-_CORRUPTION_MARKERS = ("malformed", "not a database", "file is encrypted")
+_CORRUPTION_MARKERS: tuple[str, ...] = ("malformed", "not a database", "file is encrypted")
 
 
 def _is_corruption(exc: sqlite3.DatabaseError) -> bool:
@@ -83,7 +84,7 @@ class Database:
         except sqlite3.DatabaseError as exc:
             if not _is_corruption(exc):
                 raise
-            logger.warning("Database corrupt at %s (%s) — moving it aside and recreating", db_path, exc)
+            logger.warning(f"Database corrupt at {db_path} ({exc}) — moving it aside and recreating")
             self._move_corrupt_aside(db_path)
             self._conn = self._connect(db_path)
         atexit.register(self.close)
@@ -107,7 +108,9 @@ class Database:
     @staticmethod
     def _move_corrupt_aside(db_path: str) -> None:
         """Preserve a corrupt database (and WAL/SHM siblings) instead of deleting it."""
-        stamp = int(time.time())
+        # Second-resolution timestamps can collide across rapid recoveries;
+        # the random suffix keeps an earlier backup from being overwritten.
+        stamp = f"{int(time.time())}-{uuid.uuid4().hex[:4]}"
         for suffix in ("", "-wal", "-shm"):
             src = f"{db_path}{suffix}"
             if os.path.exists(src):

--- a/src/music_downloader/persistence/database.py
+++ b/src/music_downloader/persistence/database.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import os
 import sqlite3
+import time
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -62,36 +63,60 @@ CREATE INDEX IF NOT EXISTS idx_import_jobs_status ON import_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_download_history_created ON download_history(created_at);
 """
 
+# sqlite3.OperationalError (disk full, disk I/O error, readonly database,
+# locked database) is a SUBCLASS of DatabaseError. Only genuine file
+# corruption justifies replacing the database; everything else must
+# propagate so a transient condition can't destroy history.
+_CORRUPTION_MARKERS = ("malformed", "not a database", "file is encrypted")
+
+
+def _is_corruption(exc: sqlite3.DatabaseError) -> bool:
+    text = str(exc).lower()
+    return any(marker in text for marker in _CORRUPTION_MARKERS)
+
 
 class Database:
     def __init__(self, db_path: str) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         try:
-            self._conn = sqlite3.connect(db_path, check_same_thread=False)
-            self._conn.row_factory = sqlite3.Row
-            self._conn.execute("PRAGMA journal_mode=WAL")
-            self._conn.execute("PRAGMA busy_timeout=5000")
-            self._conn.execute("PRAGMA foreign_keys=ON")
-            self._init_schema()
-        except sqlite3.DatabaseError:
-            logger.warning("Database corrupt or unreadable at %s — recreating", db_path)
-            if os.path.exists(db_path):
-                os.remove(db_path)
-            self._conn = sqlite3.connect(db_path, check_same_thread=False)
-            self._conn.row_factory = sqlite3.Row
-            self._conn.execute("PRAGMA journal_mode=WAL")
-            self._conn.execute("PRAGMA busy_timeout=5000")
-            self._conn.execute("PRAGMA foreign_keys=ON")
-            self._init_schema()
+            self._conn = self._connect(db_path)
+        except sqlite3.DatabaseError as exc:
+            if not _is_corruption(exc):
+                raise
+            logger.warning("Database corrupt at %s (%s) — moving it aside and recreating", db_path, exc)
+            self._move_corrupt_aside(db_path)
+            self._conn = self._connect(db_path)
         atexit.register(self.close)
+
+    @staticmethod
+    def _connect(db_path: str) -> sqlite3.Connection:
+        conn = sqlite3.connect(db_path, check_same_thread=False)
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute("PRAGMA foreign_keys=ON")
+            conn.executescript(_SCHEMA)
+            conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+        except Exception:
+            with contextlib.suppress(Exception):
+                conn.close()
+            raise
+        return conn
+
+    @staticmethod
+    def _move_corrupt_aside(db_path: str) -> None:
+        """Preserve a corrupt database (and WAL/SHM siblings) instead of deleting it."""
+        stamp = int(time.time())
+        for suffix in ("", "-wal", "-shm"):
+            src = f"{db_path}{suffix}"
+            if os.path.exists(src):
+                with contextlib.suppress(OSError):
+                    os.replace(src, f"{db_path}.corrupt-{stamp}{suffix}")
 
     @property
     def connection(self) -> sqlite3.Connection:
         return self._conn
-
-    def _init_schema(self) -> None:
-        self._conn.executescript(_SCHEMA)
-        self._conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
     def close(self) -> None:
         with contextlib.suppress(Exception):

--- a/src/music_downloader/persistence/import_repo.py
+++ b/src/music_downloader/persistence/import_repo.py
@@ -74,6 +74,20 @@ class ImportRepository:
         self._conn.commit()
         return cursor.lastrowid  # type: ignore[return-value]
 
+    def cancel_stale_jobs(self) -> int:
+        """Cancel every job stuck in pending/active (e.g. left over from a restart).
+
+        Runs at startup: no import can genuinely be running before the bot is,
+        so any such row is stale state that would otherwise block /import forever.
+        Returns the number of jobs cancelled.
+        """
+        cursor = self._conn.execute(
+            "UPDATE import_jobs SET status = 'cancelled', updated_at = datetime('now') "
+            "WHERE status IN ('pending', 'active')"
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
     def get_active_job(self, chat_id: int) -> ImportJob | None:
         cursor = self._conn.execute(
             "SELECT * FROM import_jobs WHERE chat_id = ? AND status IN ('pending', 'active') LIMIT 1",

--- a/src/music_downloader/search/slskd_client.py
+++ b/src/music_downloader/search/slskd_client.py
@@ -113,8 +113,12 @@ class ActiveDownload:
 class SlskdClient:
     """Wrapper around slskd-api for search and download operations."""
 
+    # Per-request HTTP timeout. Without it slskd-api defaults to no timeout at
+    # all, so a hung (not down) slskd blocks the caller forever.
+    HTTP_TIMEOUT_SECS = 15
+
     def __init__(self, host: str, api_key: str):
-        self.client = slskd_api.SlskdClient(host, api_key)
+        self.client = slskd_api.SlskdClient(host, api_key, timeout=self.HTTP_TIMEOUT_SECS)
         logger.info(f"slskd client initialized for {host}")
 
     async def search(self, query: str, timeout_secs: int = 30, response_limit: int = 500) -> list[dict]:
@@ -400,7 +404,7 @@ class SlskdClient:
 
         while time.time() - start < timeout_secs:
             await asyncio.sleep(3)
-            status = self.get_download_status(username, filename)
+            status = await asyncio.to_thread(self.get_download_status, username, filename)
 
             if status is None:
                 logger.debug(f"No status yet for {filename}")

--- a/src/music_downloader/search/slskd_client.py
+++ b/src/music_downloader/search/slskd_client.py
@@ -115,7 +115,7 @@ class SlskdClient:
 
     # Per-request HTTP timeout. Without it slskd-api defaults to no timeout at
     # all, so a hung (not down) slskd blocks the caller forever.
-    HTTP_TIMEOUT_SECS = 15
+    HTTP_TIMEOUT_SECS: int = 15
 
     def __init__(self, host: str, api_key: str):
         self.client = slskd_api.SlskdClient(host, api_key, timeout=self.HTTP_TIMEOUT_SECS)

--- a/tests/test_handlers_comprehensive.py
+++ b/tests/test_handlers_comprehensive.py
@@ -84,6 +84,7 @@ def _make_update(user_id=12345, chat_id=67890, text="Nancy Sinatra Bang Bang"):
     update.message = AsyncMock()
     update.message.text = text
     update.message.reply_text = AsyncMock()
+    update.effective_message = update.message
     return update
 
 
@@ -280,7 +281,10 @@ class TestMusicBotAuthorization:
         update = _make_update(user_id=99999)
         result = await bot._check_auth(update)
         assert result is False
-        update.message.reply_text.assert_called_once_with("You are not authorized to use this bot.")
+        update.message.reply_text.assert_called_once()
+        denial = update.message.reply_text.call_args[0][0]
+        assert "not authorized" in denial
+        assert "99999" in denial  # user ID included so they can self-serve the allowlist
 
     @patch("music_downloader.bot.handlers.SpotifyResolver")
     @patch("music_downloader.bot.handlers.SlskdClient")
@@ -373,7 +377,8 @@ class TestMusicBotCommands:
         update = _make_update(user_id=99999)
         context = _make_context()
         await bot.cmd_start(update, context)
-        update.message.reply_text.assert_called_once_with("You are not authorized to use this bot.")
+        update.message.reply_text.assert_called_once()
+        assert "not authorized" in update.message.reply_text.call_args[0][0]
 
     @patch("music_downloader.bot.handlers.SpotifyResolver")
     @patch("music_downloader.bot.handlers.SlskdClient")
@@ -855,9 +860,11 @@ class TestMusicBotHelpers:
         bot = MusicBot(_make_config())
         id1 = bot._next_dl_id()
         id2 = bot._next_dl_id()
+        # Random, not sequential: sequential IDs repeat after a restart and let
+        # stale approve/reject buttons act on unrelated new downloads.
         assert id1 != id2
-        assert id1 == "1"
-        assert id2 == "2"
+        assert len(id1) == 8
+        int(id1, 16)  # hex
 
 
 class TestMusicBotHandleText:
@@ -896,7 +903,8 @@ class TestMusicBotHandleText:
         update = _make_update(user_id=99999, text="test")
         context = _make_context()
         await bot.handle_text(update, context)
-        update.message.reply_text.assert_called_once_with("You are not authorized to use this bot.")
+        update.message.reply_text.assert_called_once()
+        assert "not authorized" in update.message.reply_text.call_args[0][0]
 
 
 class TestMusicBotDoSearch:
@@ -1115,8 +1123,8 @@ class TestRetryResultIndex:
         with patch.object(bot, "_do_download", new_callable=AsyncMock) as mock_dl:
             await bot.handle_callback(update, context)
             mock_dl.assert_called_once()
-            # result_index is the last positional arg
-            assert mock_dl.call_args[0][-1] == 3
+            # (context, chat_id, track, result, status_msg, result_index, search_id)
+            assert mock_dl.call_args[0][5] == 3
 
     @patch("music_downloader.bot.handlers.SpotifyResolver")
     @patch("music_downloader.bot.handlers.SlskdClient")
@@ -1153,7 +1161,7 @@ class TestRetryResultIndex:
             # Should download results[3] with index=3
             call_args = mock_dl.call_args[0]
             assert call_args[3] == results[3]  # next_result
-            assert call_args[-1] == 3  # next_idx
+            assert call_args[5] == 3  # next_idx (search_id is the last arg)
 
     @patch("music_downloader.bot.handlers.SpotifyResolver")
     @patch("music_downloader.bot.handlers.SlskdClient")

--- a/tests/test_import_handlers.py
+++ b/tests/test_import_handlers.py
@@ -291,6 +291,7 @@ class TestCmdCancel:
     @patch("music_downloader.bot.handlers.asyncio.to_thread", side_effect=_fake_to_thread)
     async def test_cmd_cancel_no_work(self, mock_thread):
         bot = _setup_bot()
+        bot.import_repo.get_active_job.return_value = None
         update = _make_update(chat_id=67890, text="/cancel")
         context = _make_context()
         await bot.cmd_cancel(update, context)

--- a/tests/test_keyboards.py
+++ b/tests/test_keyboards.py
@@ -40,11 +40,15 @@ def _make_track(idx: int = 0) -> TrackInfo:
 class TestBuildResultsKeyboard:
     def test_single_result(self):
         results = [_make_result()]
-        kb = build_results_keyboard(results)
+        kb = build_results_keyboard(results, search_id="abc12345")
         rows = kb.inline_keyboard
         # 1 result button + action row (auto-pick + cancel)
         assert len(rows) == 2
-        assert "dl:0" in rows[0][0].callback_data
+        # Callback data carries the search id so stale keyboards can't
+        # resolve against a newer result list.
+        assert rows[0][0].callback_data == "dl:abc12345:0"
+        assert rows[1][0].callback_data == "dl:abc12345:auto"
+        assert rows[1][1].callback_data == "dl:abc12345:cancel"
 
     def test_multiple_results(self):
         results = [_make_result(i) for i in range(3)]

--- a/tests/test_keyboards.py
+++ b/tests/test_keyboards.py
@@ -52,14 +52,14 @@ class TestBuildResultsKeyboard:
 
     def test_multiple_results(self):
         results = [_make_result(i) for i in range(3)]
-        kb = build_results_keyboard(results)
+        kb = build_results_keyboard(results, search_id="s1")
         rows = kb.inline_keyboard
         # 3 result rows + action row
         assert len(rows) == 4
 
     def test_pagination_first_page(self):
         results = [_make_result(i) for i in range(15)]
-        kb = build_results_keyboard(results, page=0, page_size=10)
+        kb = build_results_keyboard(results, page=0, page_size=10, search_id="s1")
         rows = kb.inline_keyboard
         # 10 result rows + nav row + action row
         nav_row = rows[-2]
@@ -68,7 +68,7 @@ class TestBuildResultsKeyboard:
 
     def test_pagination_second_page(self):
         results = [_make_result(i) for i in range(15)]
-        kb = build_results_keyboard(results, page=1, page_size=10)
+        kb = build_results_keyboard(results, page=1, page_size=10, search_id="s1")
         rows = kb.inline_keyboard
         nav_row = rows[-2]
         assert any("Prev" in btn.text for btn in nav_row)
@@ -76,7 +76,7 @@ class TestBuildResultsKeyboard:
 
     def test_pagination_middle_page(self):
         results = [_make_result(i) for i in range(30)]
-        kb = build_results_keyboard(results, page=1, page_size=10)
+        kb = build_results_keyboard(results, page=1, page_size=10, search_id="s1")
         rows = kb.inline_keyboard
         nav_row = rows[-2]
         assert any("Prev" in btn.text for btn in nav_row)
@@ -84,14 +84,14 @@ class TestBuildResultsKeyboard:
 
     def test_action_row_has_auto_and_cancel(self):
         results = [_make_result()]
-        kb = build_results_keyboard(results)
+        kb = build_results_keyboard(results, search_id="s1")
         action_row = kb.inline_keyboard[-1]
         texts = [btn.text for btn in action_row]
         assert any("Auto" in t for t in texts)
         assert any("Cancel" in t for t in texts)
 
     def test_empty_results_has_cancel_only(self):
-        kb = build_results_keyboard([])
+        kb = build_results_keyboard([], search_id="s1")
         action_row = kb.inline_keyboard[-1]
         assert len(action_row) == 1
         assert "Cancel" in action_row[0].text

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,393 @@
+"""Regression tests for the reliability hardening pass.
+
+Covers: database self-delete on transient errors, stale import-job recovery,
+/cancel DB fallback, /status crash and cross-chat leak, guarded downloads
+cleanup, stale results keyboards, flood-control retry, edited-message
+filtering, and the slskd HTTP timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import os
+import sqlite3
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from telegram import Chat, Message, MessageEntity, Update
+from telegram.error import RetryAfter
+from telegram.ext import CommandHandler, filters
+
+from music_downloader.bot.handlers import (
+    MusicBot,
+    PendingDownload,
+    PendingSearch,
+    _safe_edit,
+)
+from music_downloader.metadata.spotify import TrackInfo
+from music_downloader.persistence.database import Database
+from music_downloader.persistence.import_repo import ImportRepository, JobStatus
+from music_downloader.search.slskd_client import SearchResult, SlskdClient
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirroring test_handlers_comprehensive style)
+# ---------------------------------------------------------------------------
+
+
+def _make_config():
+    td = tempfile.mkdtemp()
+    config = MagicMock()
+    config.telegram_bot_token = "test-token"
+    config.spotify_client_id = "test-id"
+    config.spotify_client_secret = "test-secret"
+    config.slskd_host = "http://localhost:5030"
+    config.slskd_api_key = "test-key"
+    config.telegram_allowed_users = {12345}
+    config.auto_mode = False
+    config.max_results = 5
+    config.duration_tolerance_secs = 5
+    config.exclude_keywords = ["live", "remix"]
+    config.download_dir = os.path.join(td, "downloads")
+    config.output_dir = os.path.join(td, "music")
+    config.data_dir = os.path.join(td, "data")
+    config.filename_template = "{artist} - {title}"
+    config.search_timeout_secs = 30
+    config.download_timeout_secs = 600
+    return config
+
+
+def _make_track():
+    return TrackInfo(
+        artist="Nancy Sinatra",
+        title="Bang Bang",
+        album="How Does That Grab You?",
+        duration_ms=162_000,
+        spotify_url="https://open.spotify.com/track/xxx",
+        year="1966",
+    )
+
+
+def _make_search_result(idx=0):
+    return SearchResult(
+        username=f"user{idx}",
+        filename=f"\\Music\\Nancy Sinatra - Bang Bang {idx}.flac",
+        size=30_000_000,
+        bit_rate=900,
+        bit_depth=16,
+        sample_rate=44100,
+        length=162,
+        has_free_slot=True,
+        upload_speed=1_000_000,
+        queue_length=0,
+    )
+
+
+def _make_update(user_id=12345, chat_id=67890, text="hello"):
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_chat.id = chat_id
+    update.message = AsyncMock()
+    update.message.text = text
+    update.message.reply_text = AsyncMock()
+    update.effective_message = update.message
+    return update
+
+
+def _make_callback_update(user_id=12345, chat_id=67890, data="dl:0"):
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_chat.id = chat_id
+    update.callback_query = AsyncMock()
+    update.callback_query.from_user.id = user_id
+    update.callback_query.data = data
+    return update
+
+
+def _make_context():
+    context = MagicMock()
+    context.bot = AsyncMock()
+    context.application = MagicMock()
+    context.application.create_task = MagicMock(side_effect=lambda coro, **kw: asyncio.ensure_future(coro))
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Database: never destroy data over a transient error
+# ---------------------------------------------------------------------------
+
+
+class TestDatabaseSelfDeleteGuard:
+    def test_transient_operational_error_propagates_and_preserves_file(self, tmp_path):
+        """Disk-full/readonly must NOT be treated as corruption: no delete, error raised."""
+        db_path = str(tmp_path / "importer.db")
+        Database(db_path).close()  # create a real, healthy DB with content
+        size_before = os.path.getsize(db_path)
+
+        with (
+            patch.object(
+                Database,
+                "_connect",
+                side_effect=sqlite3.OperationalError("database or disk is full"),
+            ),
+            pytest.raises(sqlite3.OperationalError),
+        ):
+            Database(db_path)
+
+        # The healthy file is untouched — not deleted, not renamed aside.
+        assert os.path.exists(db_path)
+        assert os.path.getsize(db_path) == size_before
+        assert not list(tmp_path.glob("*.corrupt-*"))
+
+    def test_corruption_moves_file_aside_instead_of_deleting(self, tmp_path):
+        """Positive control: real corruption still recreates, but preserves the old file."""
+        db_path = str(tmp_path / "importer.db")
+        with open(db_path, "wb") as f:
+            f.write(b"SQLite format 3\x00" + b"\xff" * 200)
+
+        db = Database(db_path)
+        cursor = db.connection.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        assert {row[0] for row in cursor.fetchall()} >= {"download_history", "import_jobs"}
+        db.close()
+
+        corrupt_copies = list(tmp_path.glob("importer.db.corrupt-*"))
+        assert len(corrupt_copies) == 1, "corrupt DB should be moved aside, not deleted"
+
+
+# ---------------------------------------------------------------------------
+# Import job lifecycle: no permanent bricks
+# ---------------------------------------------------------------------------
+
+
+class TestImportJobRecovery:
+    def _repo(self, tmp_path):
+        db = Database(str(tmp_path / "importer.db"))
+        return ImportRepository(db)
+
+    def test_cancel_stale_jobs_clears_pending_and_active(self, tmp_path):
+        repo = self._repo(tmp_path)
+        repo.create_job(chat_id=1, spotify_url="u", name="a", total_tracks=3)  # stays 'pending'
+        job2 = repo.create_job(chat_id=2, spotify_url="u", name="b", total_tracks=3)
+        repo.update_job_status(job2, JobStatus.active)
+
+        assert repo.cancel_stale_jobs() == 2
+        assert repo.get_active_job(1) is None
+        assert repo.get_active_job(2) is None
+
+    @pytest.mark.asyncio
+    async def test_cmd_cancel_falls_back_to_db_job(self, tmp_path):
+        """An abandoned confirm screen leaves a pending row with no in-memory state;
+        /cancel must still clear it instead of reporting 'Nothing to cancel.'"""
+        with (
+            patch("music_downloader.bot.handlers.SpotifyResolver"),
+            patch("music_downloader.bot.handlers.SlskdClient"),
+        ):
+            bot = MusicBot(_make_config())
+        job_id = bot.import_repo.create_job(chat_id=67890, spotify_url="u", name="stuck", total_tracks=5)
+        assert bot.import_repo.get_active_job(67890) is not None
+        assert 67890 not in bot._active_import  # the brick precondition
+
+        update = _make_update(chat_id=67890, text="/cancel")
+        await bot.cmd_cancel(update, _make_context())
+
+        assert bot.import_repo.get_active_job(67890) is None, f"job {job_id} must be cancelled"
+        assert "Import cancelled" in update.message.reply_text.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# /status: no crash mid-search, no cross-chat leak
+# ---------------------------------------------------------------------------
+
+
+class TestStatusCommand:
+    def _bot(self):
+        with (
+            patch("music_downloader.bot.handlers.SpotifyResolver"),
+            patch("music_downloader.bot.handlers.SlskdClient"),
+        ):
+            return MusicBot(_make_config())
+
+    @pytest.mark.asyncio
+    async def test_status_with_unresolved_search_does_not_crash(self):
+        """PendingSearch(track=None) is a routine state (Spotify disambiguation)."""
+        bot = self._bot()
+        bot.pending[67890] = PendingSearch(query="some song", track=None)
+
+        update = _make_update(chat_id=67890)
+        await bot.cmd_status(update, _make_context())
+
+        update.message.reply_text.assert_called_once()
+        assert "some song" in update.message.reply_text.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_status_only_shows_own_chat(self):
+        bot = self._bot()
+        bot.pending[111] = PendingSearch(query="other users song", track=_make_track())
+        bot.downloads["aa"] = PendingDownload(track=_make_track(), result=_make_search_result(), chat_id=111)
+
+        update = _make_update(chat_id=67890)
+        await bot.cmd_status(update, _make_context())
+
+        text = update.message.reply_text.call_args[0][0]
+        assert text == "No active searches or downloads."
+
+
+# ---------------------------------------------------------------------------
+# Downloads cleanup: a read-only mount must not break reject/dismiss
+# ---------------------------------------------------------------------------
+
+
+class TestGuardedDownloadCleanup:
+    @pytest.mark.asyncio
+    async def test_reject_survives_undeletable_file(self, tmp_path):
+        with (
+            patch("music_downloader.bot.handlers.SpotifyResolver"),
+            patch("music_downloader.bot.handlers.SlskdClient"),
+        ):
+            bot = MusicBot(_make_config())
+
+        source = tmp_path / "track.flac"
+        source.write_bytes(b"flac")
+        dl_id = "deadbeef"
+        bot.downloads[dl_id] = PendingDownload(
+            track=_make_track(),
+            result=_make_search_result(),
+            chat_id=67890,
+            source_path=str(source),
+        )
+
+        update = _make_callback_update(chat_id=67890, data=f"reject:{dl_id}")
+        with patch("music_downloader.bot.handlers.os.remove", side_effect=PermissionError("read-only")):
+            await bot.handle_callback(update, _make_context())
+
+        # The flow completed: entry removed, message edited, history recorded.
+        assert dl_id not in bot.downloads
+        update.callback_query.edit_message_caption.assert_called()
+        records = bot.history_repo.get_recent(5)
+        assert records and records[0].status == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Stale results keyboards
+# ---------------------------------------------------------------------------
+
+
+class TestStaleResultsKeyboard:
+    def _bot_with_search(self, search_id="newsrch1"):
+        with (
+            patch("music_downloader.bot.handlers.SpotifyResolver"),
+            patch("music_downloader.bot.handlers.SlskdClient"),
+        ):
+            bot = MusicBot(_make_config())
+        bot.pending[67890] = PendingSearch(
+            query="q",
+            track=_make_track(),
+            results=[_make_search_result(i) for i in range(3)],
+            search_id=search_id,
+        )
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_button_from_older_search_is_refused(self):
+        bot = self._bot_with_search()
+        update = _make_callback_update(chat_id=67890, data="dl:oldsrch9:1")
+        context = _make_context()
+
+        await bot.handle_callback(update, context)
+
+        context.application.create_task.assert_not_called()
+        assert "out of date" in update.callback_query.edit_message_text.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_legacy_button_without_search_id_is_refused(self):
+        bot = self._bot_with_search()
+        update = _make_callback_update(chat_id=67890, data="dl:1")
+        context = _make_context()
+
+        await bot.handle_callback(update, context)
+
+        context.application.create_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_matching_search_id_downloads(self):
+        """Positive control: the guard must not refuse the current keyboard."""
+        bot = self._bot_with_search(search_id="cursrch1")
+        update = _make_callback_update(chat_id=67890, data="dl:cursrch1:1")
+        context = _make_context()
+
+        with patch.object(bot, "_do_download", new_callable=AsyncMock) as mock_dl:
+            await bot.handle_callback(update, context)
+            await asyncio.sleep(0)  # let the created task run
+            mock_dl.assert_called_once()
+            assert mock_dl.call_args[0][6] == "cursrch1"
+
+
+# ---------------------------------------------------------------------------
+# Telegram flood control
+# ---------------------------------------------------------------------------
+
+
+class TestFloodControl:
+    @pytest.mark.asyncio
+    async def test_safe_edit_waits_out_retry_after(self):
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock(side_effect=[RetryAfter(0), None])
+        with patch("music_downloader.bot.handlers.asyncio.sleep", new_callable=AsyncMock):
+            assert await _safe_edit(msg, "text") is True
+        assert msg.edit_text.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_safe_edit_gives_up_after_second_flood(self):
+        msg = AsyncMock()
+        msg.edit_text = AsyncMock(side_effect=[RetryAfter(0), RetryAfter(0)])
+        with patch("music_downloader.bot.handlers.asyncio.sleep", new_callable=AsyncMock):
+            assert await _safe_edit(msg, "text") is False
+
+
+# ---------------------------------------------------------------------------
+# Edited messages must not reach the handlers
+# ---------------------------------------------------------------------------
+
+
+class TestEditedMessageFiltering:
+    def _message(self, text, entities=()):
+        message = Message(
+            message_id=1,
+            date=datetime.datetime.now(datetime.UTC),
+            chat=Chat(id=1, type="private"),
+            text=text,
+            entities=list(entities),
+        )
+        bot = MagicMock()
+        bot.username = "testbot"
+        message.set_bot(bot)  # CommandHandler.check_update needs it to strip /cmd@botname
+        return message
+
+    def test_text_filter_rejects_edited_message(self):
+        flt = filters.TEXT & ~filters.COMMAND & filters.UpdateType.MESSAGE
+        edited = Update(update_id=1, edited_message=self._message("fixed typo"))
+        fresh = Update(update_id=2, message=self._message("new song"))
+        assert not flt.check_update(edited)
+        assert flt.check_update(fresh)  # positive control
+
+    def test_command_handler_rejects_edited_command(self):
+        handler = CommandHandler("status", AsyncMock(), filters=filters.UpdateType.MESSAGE)
+        cmd_entity = MessageEntity(type="bot_command", offset=0, length=7)
+        edited = Update(update_id=1, edited_message=self._message("/status", [cmd_entity]))
+        fresh = Update(update_id=2, message=self._message("/status", [cmd_entity]))
+        assert not handler.check_update(edited)
+        assert handler.check_update(fresh)  # positive control
+
+
+# ---------------------------------------------------------------------------
+# slskd client hardening
+# ---------------------------------------------------------------------------
+
+
+class TestSlskdClientTimeout:
+    def test_client_constructed_with_http_timeout(self):
+        """Without a timeout, a hung slskd blocks the event loop forever."""
+        with patch("music_downloader.search.slskd_client.slskd_api.SlskdClient") as mock_cls:
+            SlskdClient("http://localhost:5030", "key")
+        mock_cls.assert_called_once_with("http://localhost:5030", "key", timeout=SlskdClient.HTTP_TIMEOUT_SECS)

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -391,3 +391,14 @@ class TestSlskdClientTimeout:
         with patch("music_downloader.search.slskd_client.slskd_api.SlskdClient") as mock_cls:
             SlskdClient("http://localhost:5030", "key")
         mock_cls.assert_called_once_with("http://localhost:5030", "key", timeout=SlskdClient.HTTP_TIMEOUT_SECS)
+
+
+class TestRetryAfterNormalization:
+    def test_seconds_from_int_and_timedelta(self):
+        from music_downloader.bot.handlers import _retry_after_seconds
+
+        exc = MagicMock()
+        exc.retry_after = 7
+        assert _retry_after_seconds(exc) == 7.0
+        exc.retry_after = datetime.timedelta(seconds=3)
+        assert _retry_after_seconds(exc) == 3.0


### PR DESCRIPTION
An ops review traced what actually breaks this bot at 3am. This PR closes every hang, crash, and data-loss path it found, without touching features:

- **A hung slskd froze the bot forever.** The HTTP client had no timeout and two call paths ran it directly on the event loop. Now: 15s per-request timeout + `asyncio.to_thread` on enqueue and the download poll. (tsb: no-timeout wedge)
- **Crashes were invisible.** No error handler existed; `/status` crashed whenever a search was mid-Spotify-disambiguation, and editing a sent message crashed every handler. Now: global error handler, `track=None` guard, and handlers only react to new messages. `/status` also stops leaking other chats' activity.
- **Stale buttons acted on the wrong things.** Download IDs restarted at 1 after a restart, so an old Reject could delete the wrong file; results keyboards resolved indexes against whatever search was current. Now: random download IDs, and result callbacks carry a search id that must match.
- **/import could brick itself permanently.** The job row was written before the user confirmed, and /cancel only checked memory. Now: /cancel falls back to the DB, and stale jobs are cancelled at startup.
- **A full disk deleted the database.** `OperationalError` (disk full/readonly/locked) is a subclass of `DatabaseError`, and the recovery path was `os.remove`. Now: only genuine corruption triggers recovery, and the old file is moved aside, never deleted.
- **Rejects silently did nothing in production.** The shipped compose mounts `/downloads:ro` while reject/dismiss do bare `os.remove` — verified live: 4.8GB of orphans. Now: deletes are guarded so the flow always completes, and the compose mounts read-write as the cleanup design intends.
- Telegram flood control (`RetryAfter`) is now waited out instead of escaping; `MAX_RESULTS=0` no longer divides by zero; the unauthorized reply includes the user's Telegram ID so self-hosters can fix their allowlist.

19 new regression tests (433 total, all green), including positive controls for each guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search and download actions now use unique identifiers, preventing outdated buttons from affecting newer results.
  - Import jobs interrupted by a restart are automatically cancelled and can be recovered more reliably.
  - Authorization responses now display the relevant user ID.

- **Bug Fixes**
  - Added Telegram retry handling for temporary rate limits.
  - Restricted status results to the current chat.
  - Improved cleanup of rejected and completed downloads.
  - Added safer database recovery for corrupted files and clearer handling of storage or access errors.
  - Added request timeouts to improve responsiveness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->