### PR TITLE
feat: show download progress and make every dead end escapable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,9 @@
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 
 # Comma-separated Telegram user IDs allowed to use the bot
-# Get your ID from @userinfobot on Telegram
-# If empty, anyone can use the bot (not recommended!)
+# Get your ID from @userinfobot on Telegram (or message your bot — the
+# denial reply includes your ID)
+# If empty, the bot denies EVERYONE (fail-closed) — you must set this
 TELEGRAM_ALLOWED_USERS=
 
 # ==============================================================================
@@ -53,12 +54,11 @@ OUTPUT_DIR=/music
 # DOWNLOAD BEHAVIOR
 # ==============================================================================
 
-# Auto-download best match without asking (default: false)
-# Set to true once you trust the scoring algorithm
+# Reserved — currently has no effect (auto-download is on the roadmap)
 AUTO_MODE=false
 
-# Maximum number of search results to show
-MAX_RESULTS=5
+# Maximum number of search results to show (default: 10)
+MAX_RESULTS=10
 
 # Duration tolerance when matching Spotify duration (seconds)
 # Lower = stricter matching, higher = more flexible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Telegram bot that automates music discovery and download. Resolves track metadat
 - python-telegram-bot (Telegram Bot API)
 - spotipy (Spotify Web API, Client Credentials flow)
 - slskd-api (Soulseek/slskd REST API)
-- FastAPI + uvicorn (health check endpoint)
+- stdlib http.server (health check endpoint)
 - mutagen (audio metadata)
 - Docker (image: `drumsergio/telegram-slskd-local-bot`)
 - Published on PyPI

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ python -m music_downloader run
 | *(any text)* | Search for a song and show download options |
 | `/import <spotify url>` | Import a Spotify playlist or album, track by track |
 | `/cancel` | Cancel the active import or search |
-| `/auto` | Toggle auto-download mode on/off |
+| `/auto` | Toggle auto-download mode (reserved — the toggle persists but has no effect yet) |
 | `/status` | Show active searches and downloads |
 | `/history` | Show recent download history |
 | `/help` | Show help message |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Bot: Downloaded! Nancy Sinatra - Bang Bang (My Baby Shot Me Down).flac -> /music
 ```yaml
 services:
   slskd-importer:
-    image: drumsergio/telegram-slskd-local-bot:0.1.0
+    image: drumsergio/telegram-slskd-local-bot:0.11.0
     container_name: slskd_importer
     restart: unless-stopped
     environment:
@@ -99,15 +99,15 @@ python -m music_downloader run
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `TELEGRAM_BOT_TOKEN` | Yes | — | Telegram bot token from @BotFather |
-| `TELEGRAM_ALLOWED_USERS` | No | *(open)* | Comma-separated Telegram user IDs allowed to use the bot |
+| `TELEGRAM_ALLOWED_USERS` | Yes | *(deny all)* | Comma-separated Telegram user IDs allowed to use the bot. Empty means the bot denies everyone (fail-closed) — the denial reply shows you your ID |
 | `SPOTIFY_CLIENT_ID` | Yes | — | Spotify Developer app Client ID |
 | `SPOTIFY_CLIENT_SECRET` | Yes | — | Spotify Developer app Client Secret |
 | `SLSKD_HOST` | Yes | — | slskd instance URL (e.g., `http://192.168.1.100:5030`) |
 | `SLSKD_API_KEY` | Yes | — | slskd API key (Settings > Security > API Keys) |
 | `DOWNLOAD_DIR` | No | `/downloads` | Where slskd stores completed downloads (container path) |
 | `OUTPUT_DIR` | No | `/music` | Where to place renamed FLAC files (container path) |
-| `AUTO_MODE` | No | `false` | Auto-download best match without asking |
-| `MAX_RESULTS` | No | `5` | Maximum search results shown to user |
+| `AUTO_MODE` | No | `false` | Reserved — currently has no effect (auto-download is on the roadmap) |
+| `MAX_RESULTS` | No | `10` | Maximum search results shown to user |
 | `DURATION_TOLERANCE_SECS` | No | `5` | Duration match tolerance in seconds |
 | `SEARCH_TIMEOUT_SECS` | No | `30` | slskd search timeout |
 | `DOWNLOAD_TIMEOUT_SECS` | No | `600` | Download completion timeout |
@@ -121,6 +121,8 @@ python -m music_downloader run
 | Command | Description |
 |---------|-------------|
 | *(any text)* | Search for a song and show download options |
+| `/import <spotify url>` | Import a Spotify playlist or album, track by track |
+| `/cancel` | Cancel the active import or search |
 | `/auto` | Toggle auto-download mode on/off |
 | `/status` | Show active searches and downloads |
 | `/history` | Show recent download history |
@@ -184,5 +186,5 @@ Results containing excluded keywords (live, remix, etc.) are automatically filte
 ## Links
 
 - **Repository**: https://github.com/GeiserX/telegram-slskd-local-bot
-- **Telegram Bot**: [@slskdimporterbot](https://t.me/slskdimporterbot)
+- **Telegram Bot**: [@slskdimporterbot](https://t.me/slskdimporterbot) — the author's personal instance, allow-listed; it won't respond to other users. Deploy your own to try it.
 - **Changelog**: [docs/CHANGELOG.md](docs/CHANGELOG.md)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,95 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-08-18
+
+### Fixed
+
+- A hung (not down) slskd could block the bot forever: the HTTP client now has
+  a 15s per-request timeout and all synchronous slskd calls run off the event
+  loop (`asyncio.to_thread`)
+- Crashes are no longer invisible: a global error handler logs the traceback
+  and tells the user something went wrong
+- `/status` crashed while a search was awaiting a Spotify pick, and showed
+  every chat's activity to every user — now guarded and scoped per chat
+- Edited Telegram messages crashed every handler (`update.message` is `None`);
+  handlers now only react to new messages
+- Download IDs restarted at 1 after a restart, letting a stale Reject button
+  delete the wrong file — IDs are now random and unique
+- Result keyboards from an older search could download from the current result
+  list under the old labels — callbacks now carry a search id that must match
+- `/import` could brick itself permanently (job row written before confirm,
+  `/cancel` only checked memory) — `/cancel` now falls back to the database and
+  stale jobs are cancelled at startup
+- A full or read-only disk deleted the whole database (`OperationalError` is a
+  `DatabaseError` subclass); only genuine corruption now triggers recovery,
+  and the old file is moved aside instead of deleted
+- Reject/dismiss failed silently on a read-only `/downloads` mount; deletes are
+  now guarded and the shipped compose mounts the volume read-write
+- Telegram flood control (`RetryAfter`) is waited out instead of escaping
+- `MAX_RESULTS=0` no longer divides by zero
+
+### Added
+
+- Live download progress: the "Downloading…" message updates with percent,
+  speed, and queued state instead of staying frozen for up to 10 minutes
+- "No results" replies now offer the direct Soulseek search escape hatch
+  instead of dead-ending
+- Superseded searches/downloads are marked "⏹ Superseded by a newer request"
+  instead of sitting frozen forever
+- The command menu is registered with Telegram (`/` autocomplete), and
+  `/import` and `/cancel` are finally listed in `/help` and the README
+- The unauthorized reply includes your Telegram user ID so you can copy it
+  straight into `TELEGRAM_ALLOWED_USERS`
+
+### Changed
+
+- README/docs corrected: empty `TELEGRAM_ALLOWED_USERS` denies everyone
+  (fail-closed), `MAX_RESULTS` defaults to 10, the quickstart pins the current
+  image, and `AUTO_MODE` is documented as reserved (it currently has no effect)
+
+## [0.10.0] – [0.10.5] - 2026-05-19 – 2026-05-24
+
+### Added
+
+- Direct Soulseek search prompts for `Artist - Title` so files are saved
+  exactly as requested
+
+### Fixed
+
+- Spotify result ranking: artist-name matches in the query are boosted with
+  word-level matching (original artists surface above tribute/karaoke noise)
+- Single-source version via `importlib.metadata`; packaging fixed with
+  setuptools `find_packages`
+- Hardened error handling and removed dead code (0.10.0)
+
+## [0.9.0] – [0.9.6] - 2026-05-13 – 2026-05-19
+
+### Added
+
+- Playlist/album import (`/import <spotify url>`) with per-track review
+- Direct Soulseek search flow embedded in the Spotify keyboard
+- Hi-res audio (24-bit/96kHz) preferred over CD quality in ranking
+- PyPI publishing and Codecov coverage reporting
+
+### Fixed
+
+- Searches always stop before fetching responses from slskd (empty-result bug)
+- Downloaded files always cleaned up after approve/reject/dismiss
+- Duration filtering skipped for direct searches
+
+## [0.8.0] – [0.8.3] - 2026-04-01 – 2026-04-10
+
+### Added
+
+- App icon, Docker Hub README sync, SECURITY.md, Dependabot
+
+### Fixed
+
+- FLAC Vorbis comment tags deduplicated on save (legitimate multi-value tags
+  preserved)
+- Pagination buttons no longer fail on stale callback queries
+
 ## [0.7.0] - 2026-02-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-slskd-local-bot"
-version = "0.10.5"
+version = "0.11.0"
 description = "Automated music discovery and download via Telegram bot. Resolves metadata from Spotify, searches and downloads FLAC from Soulseek (slskd), and organizes your library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -8,6 +8,7 @@ import datetime
 import logging
 import os
 import re
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from uuid import uuid4
 
@@ -54,7 +55,7 @@ from music_downloader.processor.flac_analyzer import (
     create_preview_clip,
 )
 from music_downloader.search.scorer import ResultScorer
-from music_downloader.search.slskd_client import SearchResult, SlskdClient
+from music_downloader.search.slskd_client import DownloadStatus, SearchResult, SlskdClient
 from music_downloader.tools.embed_artwork import embed_artwork_into_file, fetch_spotify_artwork
 
 logger = logging.getLogger(__name__)
@@ -1381,7 +1382,7 @@ class MusicBot:
             task.cancel()
 
     @staticmethod
-    def _make_progress_reporter(status_msg, header: str):
+    def _make_progress_reporter(status_msg: Message, header: str) -> "Callable[[DownloadStatus], Awaitable[None]]":
         """Build a progress callback that live-edits the download status message.
 
         Skips edits when the rendered line hasn't changed (Telegram rejects
@@ -1389,7 +1390,7 @@ class MusicBot:
         """
         last_line = ""
 
-        async def _report(status) -> None:
+        async def _report(status: DownloadStatus) -> None:
             nonlocal last_line
             state_lower = (status.state or "").lower()
             if "queue" in state_lower:

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass, field
 from uuid import uuid4
 
-from telegram import Message, Update
+from telegram import BotCommand, Message, Update
 from telegram.constants import ParseMode
 from telegram.error import BadRequest, NetworkError, RetryAfter, TimedOut
 from telegram.ext import (
@@ -426,6 +426,8 @@ class MusicBot:
             "Send me a song name (e.g., `Nancy Sinatra Bang Bang`) "
             "and I'll find and download it in FLAC.\n\n"
             "Commands:\n"
+            "/import — Import a Spotify playlist or album\n"
+            "/cancel — Cancel the active import or search\n"
             "/auto — Toggle auto-download mode\n"
             "/status — Show active downloads\n"
             "/history — Recent downloads\n"
@@ -549,9 +551,25 @@ class MusicBot:
             )
             return
 
-        # Cancel any in-flight search / download for this chat immediately.
+        # Cancel any in-flight search / download for this chat immediately —
+        # but first snapshot their status messages so they can be marked as
+        # superseded instead of sitting frozen at "Searching…" forever.
+        stale_message_ids = []
+        old_pending = self.pending.get(chat_id)
+        if old_pending and old_pending.message_id:
+            stale_message_ids.append(old_pending.message_id)
+        stale_message_ids += [
+            dl.status_message_id
+            for dl in self.downloads.values()
+            if dl.chat_id == chat_id and dl.status_message_id and dl.source_path is None
+        ]
         self._cancel_chat_operations(chat_id)
         generation = self._chat_generation[chat_id]
+        for message_id in stale_message_ids:
+            with contextlib.suppress(Exception):
+                await context.bot.edit_message_text(
+                    chat_id=chat_id, message_id=message_id, text="⏹ Superseded by a newer request"
+                )
 
         # Step 0: Check for similar files already in the library
         similar = self.processor.find_similar(query)
@@ -751,12 +769,18 @@ class MusicBot:
                 return
 
             if not ranked:
+                # Not a dead end: offer the manual escape hatch. The scorer
+                # also filters live/remix/duration mismatches, so "no results"
+                # regularly means "nothing survived the filters".
+                self.pending[chat_id] = PendingSearch(query=f"{track.artist} {clean_title}", track=None)
                 await _safe_edit(
                     searching_msg,
                     f"🎵 *{track.artist} - {track.title}* ({track.duration_display})\n\n"
                     f"No results found on Soulseek matching this track.\n"
-                    f"Try a different search query.",
+                    f"Try a different query, or search Soulseek directly "
+                    f"(skips the duration and live/remix filters).",
                     parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=build_direct_search_keyboard(),
                 )
                 return
 
@@ -1073,6 +1097,10 @@ class MusicBot:
                 username=result.username,
                 filename=result.filename,
                 timeout_secs=self.config.download_timeout_secs,
+                progress_cb=self._make_progress_reporter(
+                    status_msg,
+                    f"⬇️ *Downloading {label}...*\n{track.artist} - {track.title}\nFrom: `{result.username}`",
+                ),
             )
 
             if status is None or status.is_failed:
@@ -1353,6 +1381,30 @@ class MusicBot:
             task.cancel()
 
     @staticmethod
+    def _make_progress_reporter(status_msg, header: str):
+        """Build a progress callback that live-edits the download status message.
+
+        Skips edits when the rendered line hasn't changed (Telegram rejects
+        no-op edits, and queued transfers can sit unchanged for minutes).
+        """
+        last_line = ""
+
+        async def _report(status) -> None:
+            nonlocal last_line
+            state_lower = (status.state or "").lower()
+            if "queue" in state_lower:
+                line = "⏳ Queued at the source…"
+            else:
+                speed = f" · {status.average_speed / (1024 * 1024):.1f} MB/s" if status.average_speed else ""
+                line = f"{status.percent_complete:.0f}%{speed}"
+            if line == last_line:
+                return
+            last_line = line
+            await _safe_edit(status_msg, f"{header}\n{line}", parse_mode=ParseMode.MARKDOWN)
+
+        return _report
+
+    @staticmethod
     def _remove_download_file(path: str | None) -> None:
         """Delete a file from the downloads dir, never letting failure break the flow.
 
@@ -1369,13 +1421,17 @@ class MusicBot:
             logger.warning("Could not delete %s (downloads mount read-only?): %s", path, exc)
 
     @staticmethod
-    async def _edit_approval_message(query, text: str):
-        """Edit the approval message — works for both audio captions and text messages."""
+    async def _edit_approval_message(query, text: str, reply_markup=None):
+        """Edit the approval message — works for both audio captions and text messages.
+
+        Editing without reply_markup strips the buttons; pass it explicitly
+        when the message must stay actionable.
+        """
         try:
-            await query.edit_message_caption(caption=text, parse_mode=ParseMode.MARKDOWN)
+            await query.edit_message_caption(caption=text, parse_mode=ParseMode.MARKDOWN, reply_markup=reply_markup)
         except Exception:
             with contextlib.suppress(Exception):
-                await query.edit_message_text(text=text, parse_mode=ParseMode.MARKDOWN)
+                await query.edit_message_text(text=text, parse_mode=ParseMode.MARKDOWN, reply_markup=reply_markup)
 
     # =========================================================================
     # DIRECT SEARCH (skip Spotify)
@@ -1436,10 +1492,12 @@ class MusicBot:
                 return
 
             if not ranked:
+                self.pending[chat_id] = PendingSearch(query=query, track=None)
                 await _safe_edit(
                     searching_msg,
                     f"\U0001f50e Direct search: `{query}`\n\nNo results found on Soulseek.",
                     parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=build_direct_search_keyboard(),
                 )
                 return
 
@@ -1644,7 +1702,13 @@ class MusicBot:
             return
 
         if not pending_dl.source_path:
-            await self._edit_approval_message(query, "❌ Source file not ready. Download may still be in progress.")
+            # Keep the buttons alive: stripping them here would freeze the
+            # whole import with no way forward once the download finishes.
+            await self._edit_approval_message(
+                query,
+                "❌ Source file not ready. Download may still be in progress — try again in a moment.",
+                reply_markup=build_import_track_keyboard(job_id, track_id, dl_id),
+            )
             self.downloads[dl_id] = pending_dl
             return
 
@@ -1823,11 +1887,13 @@ class MusicBot:
         try:
             success = await asyncio.to_thread(self.slskd.enqueue_download, result)
             if not success:
+                # No file exists yet, so never offer a Save button here —
+                # tapping it could only strip the keyboard and stall the job.
                 await _safe_edit(
                     status_msg,
                     f"❌ Failed to enqueue from `{result.username}`",
                     parse_mode=ParseMode.MARKDOWN,
-                    reply_markup=build_import_track_keyboard(job_id, track_id, dl_id),
+                    reply_markup=build_import_skip_keyboard(job_id, track_id),
                 )
                 await asyncio.to_thread(self.import_repo.update_track_status, track_id, TrackStatus.awaiting_approval)
                 return
@@ -1836,6 +1902,11 @@ class MusicBot:
                 username=result.username,
                 filename=result.filename,
                 timeout_secs=self.config.download_timeout_secs,
+                progress_cb=self._make_progress_reporter(
+                    status_msg,
+                    f"\U0001f4cb *Import track:* {track.artist} - {track.title}\n"
+                    f"⬇️ Downloading: `{result.basename}`\nFrom: `{result.username}`",
+                ),
             )
 
             if status is None or status.is_failed:
@@ -1854,7 +1925,7 @@ class MusicBot:
                 await _safe_edit(
                     status_msg,
                     "❌ Downloaded file not found on disk.",
-                    reply_markup=build_import_track_keyboard(job_id, track_id, dl_id),
+                    reply_markup=build_import_skip_keyboard(job_id, track_id),
                 )
                 await asyncio.to_thread(self.import_repo.update_track_status, track_id, TrackStatus.awaiting_approval)
                 return
@@ -2175,6 +2246,24 @@ class MusicBot:
         )
 
 
+async def _register_commands(app: Application) -> None:
+    """Publish the command menu so Telegram's `/` autocomplete shows every command.
+
+    Without this the biggest feature in the bot (/import) is invisible: nothing
+    in the UI ever reveals it exists.
+    """
+    await app.bot.set_my_commands(
+        [
+            BotCommand("import", "Import a Spotify playlist or album"),
+            BotCommand("cancel", "Cancel the active import or search"),
+            BotCommand("auto", "Toggle auto-download mode"),
+            BotCommand("status", "Show active searches and downloads"),
+            BotCommand("history", "Recent downloads"),
+            BotCommand("help", "How to use the bot"),
+        ]
+    )
+
+
 def create_bot(config: Config) -> Application:
     """
     Create and configure the Telegram bot application.
@@ -2187,7 +2276,7 @@ def create_bot(config: Config) -> Application:
     """
     bot = MusicBot(config)
 
-    app = Application.builder().token(config.telegram_bot_token).build()
+    app = Application.builder().token(config.telegram_bot_token).post_init(_register_commands).build()
 
     # Only react to NEW messages: an edited message arrives with
     # update.message=None and would crash every handler that replies.

--- a/src/music_downloader/search/slskd_client.py
+++ b/src/music_downloader/search/slskd_client.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 import requests.exceptions
@@ -393,7 +394,7 @@ class SlskdClient:
         username: str,
         filename: str,
         timeout_secs: int = 600,
-        progress_cb=None,
+        progress_cb: "Callable[[DownloadStatus], Awaitable[None]] | None" = None,
         progress_interval_secs: float = 10.0,
     ) -> DownloadStatus | None:
         """

--- a/src/music_downloader/search/slskd_client.py
+++ b/src/music_downloader/search/slskd_client.py
@@ -388,7 +388,14 @@ class SlskdClient:
             logger.exception(f"Failed to get download status for {filename}")
             return None
 
-    async def wait_for_download(self, username: str, filename: str, timeout_secs: int = 600) -> DownloadStatus | None:
+    async def wait_for_download(
+        self,
+        username: str,
+        filename: str,
+        timeout_secs: int = 600,
+        progress_cb=None,
+        progress_interval_secs: float = 10.0,
+    ) -> DownloadStatus | None:
         """
         Wait for a download to complete, polling periodically.
 
@@ -396,11 +403,17 @@ class SlskdClient:
             username: Source username.
             filename: Remote filename.
             timeout_secs: Maximum wait time.
+            progress_cb: Optional async callable receiving the in-flight
+                DownloadStatus at most every ``progress_interval_secs`` —
+                the data was previously fetched and dropped at DEBUG level,
+                leaving the user staring at a static "Downloading…".
+            progress_interval_secs: Minimum seconds between progress callbacks.
 
         Returns:
             Final DownloadStatus, or None on timeout.
         """
         start = time.time()
+        last_progress = 0.0
 
         while time.time() - start < timeout_secs:
             await asyncio.sleep(3)
@@ -417,6 +430,11 @@ class SlskdClient:
             if status.is_failed:
                 logger.warning(f"Download failed ({status.state}): {filename}")
                 return status
+
+            if progress_cb is not None and time.time() - last_progress >= progress_interval_secs:
+                last_progress = time.time()
+                with contextlib.suppress(Exception):
+                    await progress_cb(status)
 
             logger.debug(f"Download {status.percent_complete:.0f}%: {filename}")
 

--- a/tests/test_handlers_download.py
+++ b/tests/test_handlers_download.py
@@ -648,6 +648,7 @@ class TestCreateBot:
             mock_builder = MagicMock()
             mock_app = MagicMock()
             mock_builder.token.return_value = mock_builder
+            mock_builder.post_init.return_value = mock_builder
             mock_builder.build.return_value = mock_app
             mock_app_cls.builder.return_value = mock_builder
 

--- a/tests/test_ux_visibility.py
+++ b/tests/test_ux_visibility.py
@@ -1,0 +1,262 @@
+"""Tests for the UX visibility pass: download progress, no-results escape
+hatches, superseded-message marking, and command discoverability."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_downloader.bot.handlers import (
+    MusicBot,
+    PendingSearch,
+    _register_commands,
+)
+from music_downloader.metadata.spotify import TrackInfo
+from music_downloader.search.slskd_client import DownloadStatus, SlskdClient
+
+
+def _make_config():
+    td = tempfile.mkdtemp()
+    config = MagicMock()
+    config.telegram_bot_token = "test-token"
+    config.spotify_client_id = "test-id"
+    config.spotify_client_secret = "test-secret"
+    config.slskd_host = "http://localhost:5030"
+    config.slskd_api_key = "test-key"
+    config.telegram_allowed_users = {12345}
+    config.auto_mode = False
+    config.max_results = 5
+    config.duration_tolerance_secs = 5
+    config.exclude_keywords = ["live", "remix"]
+    config.download_dir = os.path.join(td, "downloads")
+    config.output_dir = os.path.join(td, "music")
+    config.data_dir = os.path.join(td, "data")
+    config.filename_template = "{artist} - {title}"
+    config.search_timeout_secs = 30
+    config.download_timeout_secs = 600
+    return config
+
+
+def _make_bot():
+    with (
+        patch("music_downloader.bot.handlers.SpotifyResolver"),
+        patch("music_downloader.bot.handlers.SlskdClient"),
+    ):
+        return MusicBot(_make_config())
+
+
+def _make_track():
+    return TrackInfo(
+        artist="Nancy Sinatra",
+        title="Bang Bang",
+        album="X",
+        duration_ms=162_000,
+        spotify_url="u",
+        year="1966",
+    )
+
+
+def _make_update(user_id=12345, chat_id=67890, text="hello"):
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.effective_chat.id = chat_id
+    update.message = AsyncMock()
+    update.message.text = text
+    update.message.reply_text = AsyncMock()
+    update.effective_message = update.message
+    return update
+
+
+def _make_context():
+    context = MagicMock()
+    context.bot = AsyncMock()
+    context.application = MagicMock()
+    context.application.create_task = MagicMock(side_effect=lambda coro, **kw: asyncio.ensure_future(coro))
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Download progress
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadProgress:
+    @pytest.mark.asyncio
+    async def test_wait_for_download_reports_progress(self):
+        """The in-flight status must reach the callback, not just a DEBUG log."""
+        with patch("music_downloader.search.slskd_client.slskd_api.SlskdClient"):
+            client = SlskdClient("http://x", "k")
+
+        active = DownloadStatus(
+            username="u", filename="f", state="InProgress", percent_complete=42.0, average_speed=2_000_000
+        )
+        complete = DownloadStatus(username="u", filename="f", state="Completed, Succeeded")
+        client.get_download_status = MagicMock(side_effect=[active, complete])
+
+        seen = []
+
+        async def progress_cb(status):
+            seen.append(status)
+
+        with patch("music_downloader.search.slskd_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.wait_for_download(
+                "u", "f", timeout_secs=60, progress_cb=progress_cb, progress_interval_secs=0
+            )
+
+        assert result is complete
+        assert seen == [active]
+
+    @pytest.mark.asyncio
+    async def test_progress_reporter_dedupes_and_formats(self):
+        msg = AsyncMock()
+        reporter = MusicBot._make_progress_reporter(msg, "HEADER")
+
+        queued = DownloadStatus(username="u", filename="f", state="Queued, Remotely")
+        await reporter(queued)
+        await reporter(queued)  # identical line → no second edit
+        assert msg.edit_text.call_count == 1
+        assert "Queued" in msg.edit_text.call_args[0][0]
+
+        progressing = DownloadStatus(
+            username="u", filename="f", state="InProgress", percent_complete=42.0, average_speed=2 * 1024 * 1024
+        )
+        await reporter(progressing)
+        assert msg.edit_text.call_count == 2
+        text = msg.edit_text.call_args[0][0]
+        assert "42%" in text
+        assert "2.0 MB/s" in text
+
+
+# ---------------------------------------------------------------------------
+# No-results escape hatch
+# ---------------------------------------------------------------------------
+
+
+class TestNoResultsEscapeHatch:
+    @pytest.mark.asyncio
+    async def test_spotify_path_no_results_offers_direct_search(self):
+        bot = _make_bot()
+        bot.slskd.search = AsyncMock(return_value=[])
+        bot.slskd.parse_results = MagicMock(return_value=[])
+        track = _make_track()
+
+        with patch("music_downloader.bot.handlers._safe_edit", new_callable=AsyncMock) as mock_edit:
+            await bot._do_slskd_search(_make_context(), 67890, track, AsyncMock(), generation=0)
+
+        assert 67890 in bot.pending, "query must be stored for the direct-search button"
+        assert bot.pending[67890].track is None
+        final_kwargs = mock_edit.call_args.kwargs
+        assert final_kwargs.get("reply_markup") is not None, "no-results reply must carry the escape-hatch button"
+
+    @pytest.mark.asyncio
+    async def test_direct_path_no_results_offers_retry(self):
+        bot = _make_bot()
+        bot.slskd.search = AsyncMock(return_value=[])
+        bot.slskd.parse_results = MagicMock(return_value=[])
+
+        with patch("music_downloader.bot.handlers._safe_edit", new_callable=AsyncMock) as mock_edit:
+            await bot._do_direct_slskd_search(_make_context(), 67890, "some query", AsyncMock(), generation=0)
+
+        assert 67890 in bot.pending
+        assert mock_edit.call_args.kwargs.get("reply_markup") is not None
+
+
+# ---------------------------------------------------------------------------
+# Superseded messages
+# ---------------------------------------------------------------------------
+
+
+class TestSupersededMessages:
+    @pytest.mark.asyncio
+    async def test_new_text_marks_old_search_message_superseded(self):
+        bot = _make_bot()
+        bot.processor.find_similar = MagicMock(return_value=[])
+        bot.pending[67890] = PendingSearch(query="old song", track=_make_track(), message_id=555)
+
+        update = _make_update(chat_id=67890, text="new song")
+        context = _make_context()
+        with patch.object(bot, "_do_search", new_callable=AsyncMock):
+            await bot.handle_text(update, context)
+
+        context.bot.edit_message_text.assert_called_once()
+        kwargs = context.bot.edit_message_text.call_args.kwargs
+        assert kwargs["message_id"] == 555
+        assert "Superseded" in kwargs["text"]
+
+
+# ---------------------------------------------------------------------------
+# Command discoverability
+# ---------------------------------------------------------------------------
+
+
+class TestCommandDiscoverability:
+    @pytest.mark.asyncio
+    async def test_command_menu_registered_with_import_and_cancel(self):
+        app = MagicMock()
+        app.bot = AsyncMock()
+        await _register_commands(app)
+        app.bot.set_my_commands.assert_awaited_once()
+        names = {c.command for c in app.bot.set_my_commands.call_args[0][0]}
+        assert {"import", "cancel", "auto", "status", "history", "help"} <= names
+
+    @pytest.mark.asyncio
+    async def test_help_lists_import_and_cancel(self):
+        bot = _make_bot()
+        update = _make_update()
+        await bot.cmd_start(update, _make_context())
+        text = update.message.reply_text.call_args[0][0]
+        assert "/import" in text
+        assert "/cancel" in text
+
+
+# ---------------------------------------------------------------------------
+# Import failure keyboards (no dead Save buttons)
+# ---------------------------------------------------------------------------
+
+
+class TestImportFailureKeyboards:
+    @pytest.mark.asyncio
+    async def test_enqueue_failure_offers_no_save_button(self):
+        """With no file on disk, Save could only strip the keyboard and stall the job."""
+        bot = _make_bot()
+        bot.slskd.enqueue_download = MagicMock(return_value=False)
+        bot.import_repo = MagicMock()
+
+        with patch("music_downloader.bot.handlers._safe_edit", new_callable=AsyncMock) as mock_edit:
+            await bot._do_import_download(
+                _make_context(),
+                67890,
+                _make_track(),
+                MagicMock(username="u", filename="f"),
+                AsyncMock(),
+                0,
+                job_id=1,
+                track_id=2,
+                dl_id="abc",
+            )
+
+        markup = mock_edit.call_args.kwargs["reply_markup"]
+        callbacks = [b.callback_data for row in markup.inline_keyboard for b in row]
+        assert not any(c.startswith("ia:") for c in callbacks), "no Save button without a file"
+        assert any(c.startswith("ir:") for c in callbacks)
+        assert any(c.startswith("is:") for c in callbacks)
+
+    @pytest.mark.asyncio
+    async def test_not_ready_approve_keeps_buttons(self):
+        """Tapping Save before the file lands must not strip the keyboard."""
+        from music_downloader.bot.handlers import PendingDownload
+
+        bot = _make_bot()
+        bot.downloads["abc"] = PendingDownload(track=_make_track(), result=MagicMock(), chat_id=67890, source_path=None)
+        query = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        await bot._handle_import_approve(update, _make_context(), 67890, job_id=1, track_id=2, dl_id="abc")
+
+        assert "abc" in bot.downloads, "pending download must survive the early tap"
+        assert query.edit_message_caption.call_args.kwargs.get("reply_markup") is not None

--- a/uv.lock
+++ b/uv.lock
@@ -820,7 +820,7 @@ wheels = [
 
 [[package]]
 name = "telegram-slskd-local-bot"
-version = "0.10.2"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The product/UX audit found the bot goes silent or dead-ends at exactly the moments a user most needs feedback. This PR fixes the visibility layer and ships v0.11.0:

- **Downloads are no longer a black box.** slskd's percent/speed/queued data was fetched every 3s and dropped at DEBUG level; the status message now live-updates (at most every 10s, deduped so Telegram never rejects a no-op edit).
- **"No results found" is no longer a dead end** — and it's often untrue (the scorer silently drops live/remix/duration mismatches). Both the Spotify path and direct search now offer the "Search Soulseek directly" escape hatch, with an honest note about the filters.
- **Superseded work is marked, not abandoned.** Sending a new query used to leave old messages frozen at "Searching…"/"Downloading…" forever; they now get edited to "⏹ Superseded by a newer request".
- **/import is finally discoverable.** The command menu is registered with Telegram (`/` autocomplete), and /import + /cancel appear in /help and the README — an external reviewer reading only the README concluded the import feature didn't exist.
- **Import failure states keep working buttons.** A failed enqueue/missing file no longer renders a Save button with nothing to save (tapping it stripped the keyboard and froze the job); the not-ready reply preserves the keyboard.
- **Docs stop lying**: quickstart pins the current image instead of 0.1.0 (February), empty `TELEGRAM_ALLOWED_USERS` is documented as deny-all (it always was), `MAX_RESULTS` default corrected to 10, `AUTO_MODE` is honestly marked as reserved/no-effect until the real feature lands, the live-bot link warns it's a private instance, and the CHANGELOG is backfilled 0.8.0 → 0.11.0.

Version bumped to 0.11.0 (with the reliability fixes from #35). 9 new tests; 443 total, all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/import` and `/cancel` commands to the bot menu and help message.
  * Added live download progress updates for searches and imports.
  * Added direct search and retry actions when no filtered results are found.
  * Improved import failure actions and preserved available action buttons.
* **Bug Fixes**
  * Reduced duplicate progress updates and clarified superseded status messages.
* **Documentation**
  * Updated setup guidance, authorization behavior, configuration defaults, health checks, and release history.
* **Chores**
  * Updated the project version to 0.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->