### PR TITLE
feat: sweep abandoned downloads automatically so orphans can't pile up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,10 @@ DURATION_TOLERANCE_SECS=5
 # How long to wait for slskd search results (seconds)
 SEARCH_TIMEOUT_SECS=30
 
+# Hours before abandoned files in DOWNLOAD_DIR are auto-deleted (0 disables)
+# Abandoned = never approved or rejected (superseded search, restart, timeout)
+DOWNLOAD_CLEANUP_HOURS=24
+
 # How long to wait for a download to complete (seconds)
 DOWNLOAD_TIMEOUT_SECS=600
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ffmpeg
+        # apt can hang indefinitely on a bad mirror; without the timeout a
+        # stalled update eats the full 6h job limit (bit us 2026-08-19)
+        timeout-minutes: 8
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update -qq
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends ffmpeg
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,16 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install system dependencies
-        # apt can hang indefinitely on a bad mirror; without the timeout a
-        # stalled update eats the full 6h job limit (bit us 2026-08-19)
+        # apt can hang indefinitely when the azure mirror blackholes (bit us
+        # 2026-08-19): timebox it and fall back to the main Ubuntu archive
         timeout-minutes: 8
         run: |
-          sudo apt-get -o Acquire::Retries=3 update -qq
+          if ! timeout 150 sudo apt-get -o Acquire::Retries=3 update -qq; then
+            echo "azure mirror stalled — switching to archive.ubuntu.com"
+            sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
+              /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+            sudo apt-get -o Acquire::Retries=3 update -qq
+          fi
           sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends ffmpeg
 
       - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,18 +16,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install system dependencies
-        # apt can hang indefinitely when the azure mirror blackholes (bit us
-        # 2026-08-19): timebox it and fall back to the main Ubuntu archive
-        timeout-minutes: 8
+      - name: Install ffmpeg (pinned static build, no apt)
+        # apt on the hosted runners can hang for hours when the Ubuntu
+        # mirrors blackhole (they took the whole morning down on 2026-08-19);
+        # GitHub-releases over 443 is the same path checkout already proved.
+        timeout-minutes: 5
         run: |
-          if ! timeout 150 sudo apt-get -o Acquire::Retries=3 update -qq; then
-            echo "azure mirror stalled — switching to archive.ubuntu.com"
-            sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' \
-              /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
-            sudo apt-get -o Acquire::Retries=3 update -qq
-          fi
-          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends ffmpeg
+          curl -fsSL --retry 3 -o /usr/local/bin/ffmpeg \
+            https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffmpeg-linux-x64
+          curl -fsSL --retry 3 -o /usr/local/bin/ffprobe \
+            https://github.com/eugeneware/ffmpeg-static/releases/download/b6.0/ffprobe-linux-x64
+          echo "ed652b2f32e0851d1946894fb8333f5b677c1b2ce6b9d187910a67f8b99da028  /usr/local/bin/ffmpeg" | sha256sum -c -
+          echo "a339171d90f7482b2db02234e261b9e00d51526391f87fa633d5da7b98a28cf4  /usr/local/bin/ffprobe" | sha256sum -c -
+          chmod +x /usr/local/bin/ffmpeg /usr/local/bin/ffprobe
+          ffmpeg -version | head -1
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ python -m music_downloader run
 | `DURATION_TOLERANCE_SECS` | No | `5` | Duration match tolerance in seconds |
 | `SEARCH_TIMEOUT_SECS` | No | `30` | slskd search timeout |
 | `DOWNLOAD_TIMEOUT_SECS` | No | `600` | Download completion timeout |
+| `DOWNLOAD_CLEANUP_HOURS` | No | `24` | Hours before abandoned files in `DOWNLOAD_DIR` are auto-deleted (hourly sweep; `0` disables). In-flight transfers are never touched |
 | `EXCLUDE_KEYWORDS` | No | `live,remix,...` | Comma-separated keywords to filter out |
 | `FILENAME_TEMPLATE` | No | `{artist} - {title}` | Output filename template |
 | `LOG_LEVEL` | No | `INFO` | Logging level |

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -326,6 +326,8 @@ class MusicBot:
         self._chat_generation: dict[int, int] = {}
         # Background tasks (downloads) tracked per chat for cancellation.
         self._active_tasks: dict[int, set[asyncio.Task]] = {}
+        # Orphan-sweep loop handle; owned here and cancelled on shutdown.
+        self._sweep_task: asyncio.Task | None = None
 
         # Persistence
         self.db = Database(f"{config.data_dir}/importer.db")
@@ -2301,13 +2303,28 @@ def create_bot(config: Config) -> Application:
     async def _post_init(app: Application) -> None:
         await _register_commands(app)
         if config.download_cleanup_hours > 0:
-            app.create_task(bot._orphan_sweep_loop())
+            # Plain asyncio task, deliberately NOT app.create_task: PTB must
+            # never await this infinite loop as part of its own lifecycle.
+            bot._sweep_task = asyncio.get_running_loop().create_task(bot._orphan_sweep_loop())
             logger.info(
                 f"Orphan sweep enabled: files older than {config.download_cleanup_hours}h "
                 f"are removed from the downloads dir hourly"
             )
 
-    app = Application.builder().token(config.telegram_bot_token).post_init(_post_init).build()
+    async def _post_shutdown(app: Application) -> None:
+        task = getattr(bot, "_sweep_task", None)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    app = (
+        Application.builder()
+        .token(config.telegram_bot_token)
+        .post_init(_post_init)
+        .post_shutdown(_post_shutdown)
+        .build()
+    )
 
     # Only react to NEW messages: an edited message arrives with
     # update.message=None and would crash every handler that replies.

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -2219,6 +2219,27 @@ class MusicBot:
             return words[0].title(), words[1].title()
         return "", query.title()
 
+    async def _orphan_sweep_loop(self) -> None:
+        """Hourly TTL sweep of abandoned files in the downloads dir.
+
+        Runs once at startup (catching leftovers from before a restart) and
+        then every hour. In-flight downloads are protected explicitly, on top
+        of the mtime-based safety in FileProcessor.sweep_orphans.
+        """
+        while True:
+            try:
+                protected = {dl.source_path for dl in self.downloads.values() if dl.source_path}
+                deleted, freed = await asyncio.to_thread(
+                    self.processor.sweep_orphans, self.config.download_cleanup_hours, protected
+                )
+                if deleted:
+                    logger.info(
+                        f"Orphan sweep: removed {deleted} abandoned file(s), freed {freed / (1024 * 1024):.0f} MB"
+                    )
+            except Exception:
+                logger.exception("Orphan sweep failed")
+            await asyncio.sleep(3600)
+
     async def on_error(self, update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Global error handler: log the crash and tell the user something broke.
 
@@ -2277,7 +2298,16 @@ def create_bot(config: Config) -> Application:
     """
     bot = MusicBot(config)
 
-    app = Application.builder().token(config.telegram_bot_token).post_init(_register_commands).build()
+    async def _post_init(app: Application) -> None:
+        await _register_commands(app)
+        if config.download_cleanup_hours > 0:
+            app.create_task(bot._orphan_sweep_loop())
+            logger.info(
+                f"Orphan sweep enabled: files older than {config.download_cleanup_hours}h "
+                f"are removed from the downloads dir hourly"
+            )
+
+    app = Application.builder().token(config.telegram_bot_token).post_init(_post_init).build()
 
     # Only react to NEW messages: an edited message arrives with
     # update.message=None and would crash every handler that replies.

--- a/src/music_downloader/config.py
+++ b/src/music_downloader/config.py
@@ -71,6 +71,11 @@ class Config:
         # How long to wait for a download to complete (seconds)
         self.download_timeout_secs = int(os.getenv("DOWNLOAD_TIMEOUT_SECS", "600"))
 
+        # Hours before an abandoned file in DOWNLOAD_DIR is swept away (0 disables).
+        # Abandoned = superseded search, restart, timeout — anything never
+        # approved or rejected. Active transfers are safe (fresh mtime).
+        self.download_cleanup_hours = max(0, int(os.getenv("DOWNLOAD_CLEANUP_HOURS", "24")))
+
         # Keywords in file paths that indicate unwanted versions
         exclude_kw = os.getenv(
             "EXCLUDE_KEYWORDS",

--- a/src/music_downloader/processor/file_handler.py
+++ b/src/music_downloader/processor/file_handler.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import shutil
+import time
 from difflib import SequenceMatcher
 
 import mutagen.flac
@@ -218,6 +219,58 @@ class FileProcessor:
         except Exception:
             logger.exception(f"Failed to cleanup: {source_path}")
             return False
+
+    def sweep_orphans(self, max_age_hours: int, protected_paths: set[str] | None = None) -> tuple[int, int]:
+        """Delete files in the downloads dir older than *max_age_hours*.
+
+        Everything landing in the downloads dir is transient: approved files
+        are copied to the library and rejected ones deleted immediately, so
+        anything left behind is an abandoned download (superseded search,
+        restart, timeout, or slskd finishing after the bot gave up). Age is
+        judged by mtime, which also keeps in-flight slskd transfers
+        inherently safe — a file still being written always has a fresh mtime.
+
+        Args:
+            max_age_hours: Minimum age before deletion; <= 0 disables the sweep.
+            protected_paths: Paths that must never be deleted (in-flight
+                PendingDownload sources), compared by realpath.
+
+        Returns:
+            Tuple of (files_deleted, bytes_freed).
+        """
+        if max_age_hours <= 0 or not os.path.isdir(self.download_dir):
+            return (0, 0)
+
+        protected = {os.path.realpath(p) for p in (protected_paths or set())}
+        cutoff = time.time() - max_age_hours * 3600
+        deleted = 0
+        freed = 0
+
+        for root, _dirs, files in os.walk(self.download_dir):
+            for name in files:
+                path = os.path.join(root, name)
+                if os.path.islink(path) or os.path.realpath(path) in protected:
+                    continue
+                try:
+                    stat = os.stat(path)
+                    if stat.st_mtime >= cutoff:
+                        continue
+                    os.remove(path)
+                    deleted += 1
+                    freed += stat.st_size
+                    logger.info(f"Orphan sweep deleted: {path}")
+                except OSError as exc:
+                    logger.warning(f"Orphan sweep could not delete {path}: {exc}")
+
+        # Prune now-empty per-user subdirectories (never the root itself)
+        for root, _dirs, _files in os.walk(self.download_dir, topdown=False):
+            if root == self.download_dir:
+                continue
+            with contextlib.suppress(OSError):
+                if not os.listdir(root):
+                    os.rmdir(root)
+
+        return (deleted, freed)
 
     @staticmethod
     def _dedup_flac_tags(filepath: str) -> None:

--- a/tests/test_handlers_comprehensive.py
+++ b/tests/test_handlers_comprehensive.py
@@ -47,6 +47,7 @@ def _make_config():
     config.filename_template = "{artist} - {title}"
     config.search_timeout_secs = 30
     config.download_timeout_secs = 600
+    config.download_cleanup_hours = 24
     return config
 
 

--- a/tests/test_handlers_download.py
+++ b/tests/test_handlers_download.py
@@ -650,6 +650,7 @@ class TestCreateBot:
             mock_app = MagicMock()
             mock_builder.token.return_value = mock_builder
             mock_builder.post_init.return_value = mock_builder
+            mock_builder.post_shutdown.return_value = mock_builder
             mock_builder.build.return_value = mock_app
             mock_app_cls.builder.return_value = mock_builder
 

--- a/tests/test_handlers_download.py
+++ b/tests/test_handlers_download.py
@@ -33,6 +33,7 @@ def _make_config():
     config.filename_template = "{artist} - {title}"
     config.search_timeout_secs = 30
     config.download_timeout_secs = 600
+    config.download_cleanup_hours = 24
     return config
 
 

--- a/tests/test_import_handlers.py
+++ b/tests/test_import_handlers.py
@@ -52,6 +52,7 @@ def _make_config():
     config.filename_template = "{artist} - {title}"
     config.search_timeout_secs = 30
     config.download_timeout_secs = 600
+    config.download_cleanup_hours = 24
     return config
 
 

--- a/tests/test_orphan_sweep.py
+++ b/tests/test_orphan_sweep.py
@@ -1,0 +1,106 @@
+"""Tests for the automatic orphan sweep of the downloads directory."""
+
+from __future__ import annotations
+
+import os
+import time
+
+from music_downloader.processor.file_handler import FileProcessor
+
+
+def _make_processor(tmp_path):
+    downloads = tmp_path / "downloads"
+    downloads.mkdir()
+    return FileProcessor(download_dir=str(downloads), output_dir=str(tmp_path / "music")), downloads
+
+
+def _make_old_file(path, hours_old=48, content=b"flac-bytes"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    old = time.time() - hours_old * 3600
+    os.utime(path, (old, old))
+    return path
+
+
+class TestSweepOrphans:
+    def test_deletes_old_keeps_fresh(self, tmp_path):
+        proc, downloads = _make_processor(tmp_path)
+        old = _make_old_file(downloads / "user1" / "old.flac")
+        fresh = downloads / "user2" / "fresh.flac"
+        fresh.parent.mkdir()
+        fresh.write_bytes(b"downloading")
+
+        deleted, freed = proc.sweep_orphans(24)
+
+        assert deleted == 1
+        assert freed == len(b"flac-bytes")
+        assert not old.exists()
+        assert fresh.exists(), "a file inside the TTL window must survive"
+
+    def test_protected_paths_survive_regardless_of_age(self, tmp_path):
+        proc, downloads = _make_processor(tmp_path)
+        inflight = _make_old_file(downloads / "user1" / "inflight.flac", hours_old=72)
+
+        deleted, _ = proc.sweep_orphans(24, protected_paths={str(inflight)})
+
+        assert deleted == 0
+        assert inflight.exists()
+
+    def test_prunes_empty_user_dirs_but_never_the_root(self, tmp_path):
+        proc, downloads = _make_processor(tmp_path)
+        _make_old_file(downloads / "user1" / "album" / "old.flac")
+
+        proc.sweep_orphans(24)
+
+        assert not (downloads / "user1").exists(), "emptied per-user tree should be pruned"
+        assert downloads.exists(), "the downloads root itself must survive"
+
+    def test_zero_hours_disables_sweep(self, tmp_path):
+        proc, downloads = _make_processor(tmp_path)
+        old = _make_old_file(downloads / "old.flac")
+
+        assert proc.sweep_orphans(0) == (0, 0)
+        assert old.exists()
+
+    def test_symlinks_are_skipped(self, tmp_path):
+        proc, downloads = _make_processor(tmp_path)
+        outside = tmp_path / "precious.flac"
+        outside.write_bytes(b"library file")
+        link = downloads / "link.flac"
+        link.symlink_to(outside)
+        old = time.time() - 72 * 3600
+        os.utime(link, (old, old), follow_symlinks=False)
+
+        deleted, _ = proc.sweep_orphans(24)
+
+        assert deleted == 0
+        assert outside.exists()
+
+    def test_missing_download_dir_is_a_noop(self, tmp_path):
+        proc = FileProcessor(download_dir=str(tmp_path / "nope"), output_dir=str(tmp_path / "music"))
+        assert proc.sweep_orphans(24) == (0, 0)
+
+
+class TestCleanupHoursConfig:
+    _REQUIRED = {
+        "TELEGRAM_BOT_TOKEN": "t",
+        "SPOTIFY_CLIENT_ID": "i",
+        "SPOTIFY_CLIENT_SECRET": "s",
+        "SLSKD_HOST": "http://x",
+        "SLSKD_API_KEY": "k",
+    }
+
+    def _config(self, monkeypatch, **extra):
+        for k, v in {**self._REQUIRED, **extra}.items():
+            monkeypatch.setenv(k, v)
+        from music_downloader.config import Config
+
+        return Config()
+
+    def test_default_is_24(self, monkeypatch):
+        monkeypatch.delenv("DOWNLOAD_CLEANUP_HOURS", raising=False)
+        assert self._config(monkeypatch).download_cleanup_hours == 24
+
+    def test_zero_disables_and_negatives_clamp(self, monkeypatch):
+        assert self._config(monkeypatch, DOWNLOAD_CLEANUP_HOURS="0").download_cleanup_hours == 0
+        assert self._config(monkeypatch, DOWNLOAD_CLEANUP_HOURS="-5").download_cleanup_hours == 0

--- a/tests/test_orphan_sweep.py
+++ b/tests/test_orphan_sweep.py
@@ -2,10 +2,41 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from music_downloader.processor.file_handler import FileProcessor
+
+
+def _handlers_config():
+    """Config shaped for MusicBot construction (mirrors the handlers test fixtures)."""
+    import tempfile
+    from unittest.mock import MagicMock
+
+    td = tempfile.mkdtemp()
+    config = MagicMock()
+    config.telegram_bot_token = "test-token"
+    config.spotify_client_id = "i"
+    config.spotify_client_secret = "s"
+    config.slskd_host = "http://localhost:5030"
+    config.slskd_api_key = "k"
+    config.telegram_allowed_users = {12345}
+    config.auto_mode = False
+    config.max_results = 5
+    config.duration_tolerance_secs = 5
+    config.exclude_keywords = []
+    config.download_dir = os.path.join(td, "downloads")
+    config.output_dir = os.path.join(td, "music")
+    config.data_dir = os.path.join(td, "data")
+    config.filename_template = "{artist} - {title}"
+    config.search_timeout_secs = 30
+    config.download_timeout_secs = 600
+    config.download_cleanup_hours = 24
+    return config
 
 
 def _make_processor(tmp_path):
@@ -104,3 +135,55 @@ class TestCleanupHoursConfig:
     def test_zero_disables_and_negatives_clamp(self, monkeypatch):
         assert self._config(monkeypatch, DOWNLOAD_CLEANUP_HOURS="0").download_cleanup_hours == 0
         assert self._config(monkeypatch, DOWNLOAD_CLEANUP_HOURS="-5").download_cleanup_hours == 0
+
+
+class TestSweepLoopLifecycle:
+    @pytest.mark.asyncio
+    async def test_loop_sweeps_and_survives_errors(self):
+        """One failing sweep must not kill the hourly loop."""
+        with (
+            patch("music_downloader.bot.handlers.SpotifyResolver"),
+            patch("music_downloader.bot.handlers.SlskdClient"),
+        ):
+            from music_downloader.bot.handlers import MusicBot
+
+            bot = MusicBot(_handlers_config())
+        bot.processor = MagicMock()
+        bot.processor.sweep_orphans = MagicMock(side_effect=[RuntimeError("boom"), (2, 1024)])
+
+        with patch("music_downloader.bot.handlers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_sleep.side_effect = [None, asyncio.CancelledError()]
+            with pytest.raises(asyncio.CancelledError):
+                await bot._orphan_sweep_loop()
+
+        assert bot.processor.sweep_orphans.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_post_init_starts_task_and_post_shutdown_cancels_it(self):
+        from music_downloader.bot.handlers import create_bot
+
+        config = _handlers_config()
+        with (
+            patch("music_downloader.bot.handlers.SpotifyResolver"),
+            patch("music_downloader.bot.handlers.SlskdClient"),
+            patch("music_downloader.bot.handlers.Application") as mock_app_cls,
+        ):
+            mock_builder = MagicMock()
+            for chain in ("token", "post_init", "post_shutdown"):
+                getattr(mock_builder, chain).return_value = mock_builder
+            mock_builder.build.return_value = MagicMock()
+            mock_app_cls.builder.return_value = mock_builder
+            create_bot(config)
+            post_init = mock_builder.post_init.call_args[0][0]
+            post_shutdown = mock_builder.post_shutdown.call_args[0][0]
+
+        app = MagicMock()
+        app.bot = AsyncMock()
+
+        before = asyncio.all_tasks()
+        await post_init(app)
+        started = asyncio.all_tasks() - before
+        assert len(started) == 1, "post_init must start exactly the sweep task"
+
+        await post_shutdown(app)
+        assert started.pop().cancelled(), "post_shutdown must cancel the sweep task"

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -55,6 +55,7 @@ def _make_config():
     config.filename_template = "{artist} - {title}"
     config.search_timeout_secs = 30
     config.download_timeout_secs = 600
+    config.download_cleanup_hours = 24
     return config
 
 

--- a/tests/test_ux_visibility.py
+++ b/tests/test_ux_visibility.py
@@ -38,6 +38,7 @@ def _make_config():
     config.filename_template = "{artist} - {title}"
     config.search_timeout_secs = 30
     config.download_timeout_secs = 600
+    config.download_cleanup_hours = 24
     return config
 
 


### PR DESCRIPTION
Production had accumulated 4.8GB / 100 orphaned files in slskd's downloads dir (cleaned manually today — every one stale, zero active transfers). They came from downloads that were never approved or rejected: superseded searches, restarts, timeouts, and slskd finishing after the bot gave up. Nothing ever deleted them.

This adds an hourly TTL sweep (tsb-803): files in `DOWNLOAD_DIR` older than `DOWNLOAD_CLEANUP_HOURS` (default 24, `0` disables) are deleted and emptied per-user subdirs pruned. Safety is layered: in-flight `PendingDownload` sources are explicitly protected, mtime-based age makes actively-written slskd transfers inherently safe, symlinks are skipped, and the downloads root itself is never removed. The sweep runs once at startup (catching pre-restart leftovers) and then hourly, logging what it freed.

8 new tests (451 total, green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically removes abandoned download files older than 24 hours.
  * Cleanup runs hourly and protects files involved in active transfers.
  * Added the `DOWNLOAD_CLEANUP_HOURS` setting; set it to `0` to disable cleanup.

* **Bug Fixes**
  * Safely handles missing directories, symlinks, and cleanup failures without interrupting downloads.

* **Documentation**
  * Documented cleanup behavior, defaults, scheduling, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->