### PR TITLE
feat: real auto-download mode and unattended playlist imports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,9 @@ OUTPUT_DIR=/music
 # DOWNLOAD BEHAVIOR
 # ==============================================================================
 
-# Reserved — currently has no effect (auto-download is on the roadmap)
+# Default auto-download state for chats that never toggled /auto
+# When on, the best match is downloaded and saved without asking
+# Set to true once you trust the scoring algorithm
 AUTO_MODE=false
 
 # Maximum number of search results to show (default: 10)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Bot: Downloaded! Nancy Sinatra - Bang Bang (My Baby Shot Me Down).flac -> /music
 ```yaml
 services:
   slskd-importer:
-    image: drumsergio/telegram-slskd-local-bot:0.11.0
+    image: drumsergio/telegram-slskd-local-bot:0.12.0
     container_name: slskd_importer
     restart: unless-stopped
     environment:
@@ -62,7 +62,8 @@ services:
       SLSKD_HOST: "http://your-slskd-host:5030"
       SLSKD_API_KEY: "your-slskd-api-key"
     volumes:
-      - /path/to/slskd/downloads:/downloads:ro
+      # Read-write: the bot deletes rejected files and sweeps abandoned ones
+      - /path/to/slskd/downloads:/downloads
       - /path/to/music/library:/music
     logging:
       driver: "json-file"
@@ -106,7 +107,7 @@ python -m music_downloader run
 | `SLSKD_API_KEY` | Yes | — | slskd API key (Settings > Security > API Keys) |
 | `DOWNLOAD_DIR` | No | `/downloads` | Where slskd stores completed downloads (container path) |
 | `OUTPUT_DIR` | No | `/music` | Where to place renamed FLAC files (container path) |
-| `AUTO_MODE` | No | `false` | Reserved — currently has no effect (auto-download is on the roadmap) |
+| `AUTO_MODE` | No | `false` | Default auto-download state for chats that never toggled `/auto`: best match is downloaded and saved without asking |
 | `MAX_RESULTS` | No | `10` | Maximum search results shown to user |
 | `DURATION_TOLERANCE_SECS` | No | `5` | Duration match tolerance in seconds |
 | `SEARCH_TIMEOUT_SECS` | No | `30` | slskd search timeout |
@@ -122,9 +123,9 @@ python -m music_downloader run
 | Command | Description |
 |---------|-------------|
 | *(any text)* | Search for a song and show download options |
-| `/import <spotify url>` | Import a Spotify playlist or album, track by track |
+| `/import <spotify url>` | Import a Spotify playlist or album — review each track or auto-save all |
 | `/cancel` | Cancel the active import or search |
-| `/auto` | Toggle auto-download mode (reserved — the toggle persists but has no effect yet) |
+| `/auto` | Toggle auto-download per chat: best match is downloaded and saved without picking or approval (persists across restarts) |
 | `/status` | Show active searches and downloads |
 | `/history` | Show recent download history |
 | `/help` | Show help message |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-08-19
+
+### Added
+
+- **Auto-download mode is now real.** `/auto` (per chat, persisted across
+  restarts; `AUTO_MODE` is the default for chats that never toggled) skips the
+  picker and the approval step: the best-ranked match is downloaded, saved to
+  the library, tagged with artwork, and confirmed in one message
+- **Unattended playlist imports.** The import confirm screen offers
+  "Review each track" or "Auto-save all"; auto-save imports run start-to-finish
+  with no taps and no Telegram preview uploads, marking failed tracks and
+  continuing instead of pausing
+- `/status` shows import progress (mode, processed/total, saved/failed/skipped)
+- **Automatic orphan cleanup**: an hourly sweep deletes files in
+  `DOWNLOAD_DIR` older than `DOWNLOAD_CLEANUP_HOURS` (default 24, `0`
+  disables) and prunes emptied per-user folders. In-flight downloads are
+  protected explicitly, and mtime-based age keeps actively-written slskd
+  transfers safe. Production had accumulated 4.8 GB of abandoned files
+  before this existed
+
 ## [0.11.0] - 2026-08-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-slskd-local-bot"
-version = "0.11.0"
+version = "0.12.0"
 description = "Automated music discovery and download via Telegram bot. Resolves metadata from Spotify, searches and downloads FLAC from Soulseek (slskd), and organizes your library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -47,6 +47,7 @@ from music_downloader.persistence.import_repo import (
     JobStatus,
     TrackStatus,
 )
+from music_downloader.persistence.settings_repo import SettingsRepository
 from music_downloader.processor.file_handler import FileProcessor
 from music_downloader.processor.flac_analyzer import (
     FlacVerdict,
@@ -303,7 +304,9 @@ class MusicBot:
             output_dir=config.output_dir,
             filename_template=config.filename_template,
         )
-        self.auto_mode = config.auto_mode
+        # Per-chat auto-mode cache; the durable value lives in chat_settings
+        # (config.auto_mode is only the default for chats that never toggled).
+        self._auto_mode_cache: dict[int, bool] = {}
 
         # Per-user pending searches (chat_id -> PendingSearch)
         self.pending: dict[int, PendingSearch] = {}
@@ -333,6 +336,7 @@ class MusicBot:
         self.db = Database(f"{config.data_dir}/importer.db")
         self.history_repo = HistoryRepository(self.db)
         self.import_repo = ImportRepository(self.db)
+        self.settings_repo = SettingsRepository(self.db)
 
         # Playlist resolver
         self.playlist_resolver = PlaylistResolver(self.spotify)
@@ -341,12 +345,25 @@ class MusicBot:
         self._active_import: dict[int, int] = {}
         # Separate pending search state for import flows (avoids clobbering self.pending)
         self._import_pending: dict[int, PendingSearch] = {}
+        # Import runs unattended for these chats (chosen on the confirm keyboard)
+        self._import_auto: dict[int, bool] = {}
 
         # A restart cannot leave a genuinely running import behind, but it does
         # leave pending/active rows that would block /import for that chat forever.
         stale_jobs = self.import_repo.cancel_stale_jobs()
         if stale_jobs:
             logger.warning("Cancelled %d stale import job(s) left over from a previous run", stale_jobs)
+
+    def _is_auto(self, chat_id: int) -> bool:
+        """Whether auto-download is on for this chat (persisted; config is the default)."""
+        if chat_id not in self._auto_mode_cache:
+            stored = self.settings_repo.get_auto_mode(chat_id)
+            self._auto_mode_cache[chat_id] = self.config.auto_mode if stored is None else stored
+        return self._auto_mode_cache[chat_id]
+
+    def _set_auto(self, chat_id: int, enabled: bool) -> None:
+        self._auto_mode_cache[chat_id] = enabled
+        self.settings_repo.set_auto_mode(chat_id, enabled)
 
     def _is_authorized(self, user_id: int) -> bool:
         """Check if a user is authorized to use the bot (fail-closed)."""
@@ -389,6 +406,7 @@ class MusicBot:
 
         self.pending.pop(chat_id, None)
         self._import_pending.pop(chat_id, None)
+        self._import_auto.pop(chat_id, None)
         self._spotify_candidates.pop(chat_id, None)
         self._spotify_page.pop(chat_id, None)
         self._awaiting_direct_metadata.pop(chat_id, None)
@@ -449,12 +467,14 @@ class MusicBot:
         if not await self._check_auth(update):
             return
 
-        mode_str = "ON" if self.auto_mode else "OFF"
+        current = self._is_auto(update.effective_chat.id)
+        mode_str = "ON" if current else "OFF"
         await update.message.reply_text(
             f"Auto-download mode is currently: *{mode_str}*\n\n"
-            "When ON, the best FLAC match is downloaded automatically without asking you to pick.",
+            "When ON, the best match is downloaded and saved to your library "
+            "automatically — no picking, no approval step. The setting survives restarts.",
             parse_mode=ParseMode.MARKDOWN,
-            reply_markup=build_auto_mode_keyboard(self.auto_mode),
+            reply_markup=build_auto_mode_keyboard(current),
         )
 
     async def cmd_status(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -483,6 +503,15 @@ class MusicBot:
                 lines.append(
                     f"• {_escape_md(dl.track.artist)} - {_escape_md(dl.track.title)} ({_escape_md(dl.result.basename)})"
                 )
+
+        job_id = self._active_import.get(chat_id)
+        if job_id:
+            completed, failed, skipped, total = await asyncio.to_thread(self.import_repo.get_job_progress, job_id)
+            mode = "auto-save" if self._import_auto.get(chat_id) else "review"
+            lines.append(
+                f"\n*Import ({mode}):* {completed + failed + skipped}/{total} processed — "
+                f"✅ {completed} · ❌ {failed} · ⏭ {skipped}"
+            )
 
         if not lines:
             await update.message.reply_text("No active searches or downloads.")
@@ -798,6 +827,18 @@ class MusicBot:
             )
 
             results_text = self._format_results(track, ranked, is_fallback, page=0, page_size=self.config.max_results)
+
+            if self._is_auto(chat_id):
+                # Auto-mode: no picker, no approval — take the top-ranked match.
+                best = ranked[0]
+                await _safe_edit(
+                    searching_msg,
+                    f"{results_text}\n\n\U0001f916 *Auto-mode:* downloading best match #1…",
+                    parse_mode=ParseMode.MARKDOWN,
+                )
+                await self._launch_download(context, chat_id, track, best, 0, search_id)
+                return
+
             await _safe_edit(
                 searching_msg,
                 results_text,
@@ -857,8 +898,9 @@ class MusicBot:
 
         # Auto-mode toggle (inline, no separate handler needed)
         if data.startswith("auto:"):
-            self.auto_mode = data == "auto:on"
-            mode_str = "ON" if self.auto_mode else "OFF"
+            enabled = data == "auto:on"
+            self._set_auto(chat_id, enabled)
+            mode_str = "ON" if enabled else "OFF"
             await query.edit_message_text(
                 f"Auto-download mode: *{mode_str}*",
                 parse_mode=ParseMode.MARKDOWN,
@@ -1014,7 +1056,12 @@ class MusicBot:
 
         result = pending.results[index]
         track = pending.track
+        await self._launch_download(context, chat_id, track, result, index, pending.search_id, update=update)
 
+    async def _launch_download(
+        self, context, chat_id: int, track: TrackInfo, result: SearchResult, index: int, search_id: str, update=None
+    ):
+        """Send the download status message and start the download task."""
         status_msg = await context.bot.send_message(
             chat_id=chat_id,
             text=(
@@ -1027,7 +1074,7 @@ class MusicBot:
         )
 
         task = context.application.create_task(
-            self._do_download(context, chat_id, track, result, status_msg, index, pending.search_id),
+            self._do_download(context, chat_id, track, result, status_msg, index, search_id),
             update=update,
         )
         self._track_task(chat_id, task)
@@ -1151,6 +1198,10 @@ class MusicBot:
             if flac_verdict:
                 quality_line += f"\n{flac_verdict.display}"
 
+            if self._is_auto(chat_id):
+                await self._auto_save(chat_id, dl_id, pending_dl, status_msg, quality_line, label)
+                return
+
             await status_msg.edit_text(
                 f"✅ *{label} Downloaded!* Sending preview...\n`{result.basename}`\n{quality_line}",
                 parse_mode=ParseMode.MARKDOWN,
@@ -1208,6 +1259,36 @@ class MusicBot:
                 f"❌ Error downloading `{result.basename}`. Check logs.",
                 parse_mode=ParseMode.MARKDOWN,
             )
+
+    async def _auto_save(
+        self, chat_id: int, dl_id: str, pending_dl: PendingDownload, status_msg, quality_line: str, label: str
+    ):
+        """Save a downloaded file straight to the library (auto-mode: no preview, no approval)."""
+        self.downloads.pop(dl_id, None)
+        track = pending_dl.track
+        result = pending_dl.result
+
+        target_path = await asyncio.to_thread(
+            self.processor.process_file, pending_dl.source_path, track.artist, track.title
+        )
+        if target_path:
+            await asyncio.to_thread(self.processor.cleanup_download, pending_dl.source_path)
+            await self._embed_spotify_artwork(target_path, track)
+            target_name = os.path.basename(target_path)
+            await _safe_edit(
+                status_msg,
+                f"✅ *{label} Auto-saved:* `{target_name}`\n{quality_line}",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+            await self._add_history(track, result, "success")
+            logger.info(f"Auto-saved: {target_name}")
+        else:
+            await _safe_edit(
+                status_msg,
+                f"❌ {label} Downloaded but failed to save. Check logs.",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+            await self._add_history(track, result, "process_failed")
 
     async def _send_large_file(
         self,
@@ -1659,7 +1740,10 @@ class MusicBot:
             return
 
         if prefix == "ic":
-            await _safe_query_edit(query, "✅ Import started! Processing tracks one by one...")
+            auto = len(parts) > 1 and parts[1] == "auto"
+            self._import_auto[chat_id] = auto
+            mode_note = "auto-saving every track" if auto else "you review each track"
+            await _safe_query_edit(query, f"✅ Import started — {mode_note}...")
             await asyncio.to_thread(self.import_repo.update_job_status, job_id, JobStatus.active)
             self._active_import[chat_id] = job_id
             generation = self._chat_generation.get(chat_id, 0)
@@ -1672,6 +1756,7 @@ class MusicBot:
         elif prefix == "ix":
             await asyncio.to_thread(self.import_repo.update_job_status, job_id, JobStatus.cancelled)
             self._active_import.pop(chat_id, None)
+            self._import_auto.pop(chat_id, None)
             await _safe_query_edit(query, "❌ Import cancelled.")
 
         elif prefix == "ia":
@@ -1749,6 +1834,7 @@ class MusicBot:
             completed, failed, skipped, total = progress
             await asyncio.to_thread(self.import_repo.update_job_status, job_id, JobStatus.completed)
             self._active_import.pop(chat_id, None)
+            self._import_auto.pop(chat_id, None)
             await context.bot.send_message(
                 chat_id=chat_id,
                 text=f"\U0001f3c1 *Import complete!*\n\n"
@@ -1890,6 +1976,19 @@ class MusicBot:
         try:
             success = await asyncio.to_thread(self.slskd.enqueue_download, result)
             if not success:
+                if self._import_auto.get(chat_id):
+                    await self._import_auto_fail(
+                        context,
+                        chat_id,
+                        job_id,
+                        track_id,
+                        dl_id,
+                        status_msg,
+                        generation,
+                        f"❌ Failed to enqueue from `{result.username}` — continuing.",
+                        "Enqueue failed",
+                    )
+                    return
                 # No file exists yet, so never offer a Save button here —
                 # tapping it could only strip the keyboard and stall the job.
                 await _safe_edit(
@@ -1914,6 +2013,19 @@ class MusicBot:
 
             if status is None or status.is_failed:
                 state = status.state if status else "Timeout"
+                if self._import_auto.get(chat_id):
+                    await self._import_auto_fail(
+                        context,
+                        chat_id,
+                        job_id,
+                        track_id,
+                        dl_id,
+                        status_msg,
+                        generation,
+                        f"❌ Download failed ({state}): `{result.basename}` — continuing.",
+                        state,
+                    )
+                    return
                 await _safe_edit(
                     status_msg,
                     f"❌ Download failed: {state}\n`{result.basename}`",
@@ -1925,6 +2037,19 @@ class MusicBot:
 
             source_path = self.processor.find_downloaded_file(result.username, result.filename)
             if not source_path:
+                if self._import_auto.get(chat_id):
+                    await self._import_auto_fail(
+                        context,
+                        chat_id,
+                        job_id,
+                        track_id,
+                        dl_id,
+                        status_msg,
+                        generation,
+                        "❌ Downloaded file not found on disk — continuing.",
+                        "File not found on disk",
+                    )
+                    return
                 await _safe_edit(
                     status_msg,
                     "❌ Downloaded file not found on disk.",
@@ -1936,6 +2061,12 @@ class MusicBot:
             # Update PendingDownload with source path
             if dl_id in self.downloads:
                 self.downloads[dl_id].source_path = source_path
+
+            if self._import_auto.get(chat_id):
+                await self._import_auto_save(
+                    context, chat_id, job_id, track_id, dl_id, track, result, source_path, status_msg, generation
+                )
+                return
 
             # Send file for approval
             await asyncio.to_thread(self.import_repo.update_track_status, track_id, TrackStatus.awaiting_approval)
@@ -1987,6 +2118,62 @@ class MusicBot:
                 self.import_repo.complete_track, job_id, track_id, TrackStatus.failed, "Download error"
             )
             await self._process_next_import_track(context, chat_id, job_id, generation)
+
+    async def _import_auto_fail(
+        self,
+        context,
+        chat_id: int,
+        job_id: int,
+        track_id: int,
+        dl_id: str,
+        status_msg,
+        generation: int,
+        message: str,
+        reason: str,
+    ):
+        """Unattended import: mark the track failed and move on instead of pausing."""
+        self.downloads.pop(dl_id, None)
+        await _safe_edit(status_msg, message, parse_mode=ParseMode.MARKDOWN)
+        await asyncio.to_thread(self.import_repo.complete_track, job_id, track_id, TrackStatus.failed, reason)
+        await self._process_next_import_track(context, chat_id, job_id, generation)
+
+    async def _import_auto_save(
+        self,
+        context,
+        chat_id: int,
+        job_id: int,
+        track_id: int,
+        dl_id: str,
+        track: TrackInfo,
+        result: SearchResult,
+        source_path: str,
+        status_msg,
+        generation: int,
+    ):
+        """Unattended import: save the track straight to the library, no preview upload."""
+        self.downloads.pop(dl_id, None)
+        target_path = await asyncio.to_thread(self.processor.process_file, source_path, track.artist, track.title)
+        if target_path:
+            await asyncio.to_thread(self.processor.cleanup_download, source_path)
+            await self._embed_spotify_artwork(target_path, track)
+            target_name = os.path.basename(target_path)
+            await _safe_edit(
+                status_msg,
+                f"\U0001f4cb *Import:* {track.artist} - {track.title}\n✅ Auto-saved: `{target_name}`",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+            await self._add_history(track, result, "success")
+            await asyncio.to_thread(self.import_repo.complete_track, job_id, track_id, TrackStatus.completed)
+        else:
+            await _safe_edit(
+                status_msg,
+                f"\U0001f4cb *Import:* {track.artist} - {track.title}\n❌ Failed to save — continuing.",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+            await asyncio.to_thread(
+                self.import_repo.complete_track, job_id, track_id, TrackStatus.failed, "File processing failed"
+            )
+        await self._process_next_import_track(context, chat_id, job_id, generation)
 
     # =========================================================================
     # RETRY HANDLERS

--- a/src/music_downloader/bot/handlers.py
+++ b/src/music_downloader/bot/handlers.py
@@ -1264,13 +1264,15 @@ class MusicBot:
         self, chat_id: int, dl_id: str, pending_dl: PendingDownload, status_msg, quality_line: str, label: str
     ):
         """Save a downloaded file straight to the library (auto-mode: no preview, no approval)."""
-        self.downloads.pop(dl_id, None)
         track = pending_dl.track
         result = pending_dl.result
 
         target_path = await asyncio.to_thread(
             self.processor.process_file, pending_dl.source_path, track.artist, track.title
         )
+        # Popped only after processing: the entry keeps the source protected
+        # from the orphan sweep while process_file runs.
+        self.downloads.pop(dl_id, None)
         if target_path:
             await asyncio.to_thread(self.processor.cleanup_download, pending_dl.source_path)
             await self._embed_spotify_artwork(target_path, track)

--- a/src/music_downloader/bot/keyboards.py
+++ b/src/music_downloader/bot/keyboards.py
@@ -124,13 +124,12 @@ def build_direct_search_keyboard() -> InlineKeyboardMarkup:
 
 
 def build_import_confirm_keyboard(job_id: int) -> InlineKeyboardMarkup:
-    """Confirm/cancel keyboard for playlist import."""
+    """Confirm/cancel keyboard for playlist import, with a review-vs-auto choice."""
     return InlineKeyboardMarkup(
         [
-            [
-                InlineKeyboardButton("✅ Start import", callback_data=f"ic:{job_id}"),
-                InlineKeyboardButton("❌ Cancel", callback_data=f"ix:{job_id}"),
-            ]
+            [InlineKeyboardButton("▶️ Review each track", callback_data=f"ic:{job_id}")],
+            [InlineKeyboardButton("\U0001f916 Auto-save all", callback_data=f"ic:{job_id}:auto")],
+            [InlineKeyboardButton("❌ Cancel", callback_data=f"ix:{job_id}")],
         ]
     )
 

--- a/src/music_downloader/persistence/database.py
+++ b/src/music_downloader/persistence/database.py
@@ -59,6 +59,12 @@ CREATE TABLE IF NOT EXISTS import_tracks (
     UNIQUE(job_id, position)
 );
 
+CREATE TABLE IF NOT EXISTS chat_settings (
+    chat_id INTEGER PRIMARY KEY,
+    auto_mode INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_import_tracks_job_status ON import_tracks(job_id, status);
 CREATE INDEX IF NOT EXISTS idx_import_jobs_status ON import_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_download_history_created ON download_history(created_at);

--- a/src/music_downloader/persistence/settings_repo.py
+++ b/src/music_downloader/persistence/settings_repo.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from .database import Database
+
+
+class SettingsRepository:
+    """Per-chat settings that must survive restarts (currently: auto-mode)."""
+
+    def __init__(self, db: Database) -> None:
+        self._conn = db.connection
+
+    def get_auto_mode(self, chat_id: int) -> bool | None:
+        """Return the stored auto-mode flag, or None when the chat never set one."""
+        cursor = self._conn.execute(
+            "SELECT auto_mode FROM chat_settings WHERE chat_id = ?",
+            (chat_id,),
+        )
+        row = cursor.fetchone()
+        return None if row is None else bool(row["auto_mode"])
+
+    def set_auto_mode(self, chat_id: int, enabled: bool) -> None:
+        self._conn.execute(
+            "INSERT INTO chat_settings (chat_id, auto_mode, updated_at) "
+            "VALUES (?, ?, datetime('now')) "
+            "ON CONFLICT(chat_id) DO UPDATE SET auto_mode = excluded.auto_mode, updated_at = datetime('now')",
+            (chat_id, int(enabled)),
+        )
+        self._conn.commit()

--- a/tests/test_auto_mode.py
+++ b/tests/test_auto_mode.py
@@ -1,0 +1,250 @@
+"""Tests for real auto-download mode and unattended imports (v0.12.0)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_downloader.bot.handlers import MusicBot, PendingDownload
+from music_downloader.bot.keyboards import build_import_confirm_keyboard
+from music_downloader.metadata.spotify import TrackInfo
+from music_downloader.persistence.database import Database
+from music_downloader.persistence.settings_repo import SettingsRepository
+from music_downloader.search.slskd_client import SearchResult
+
+
+def _make_config(td=None):
+    td = td or tempfile.mkdtemp()
+    config = MagicMock()
+    config.telegram_bot_token = "test-token"
+    config.spotify_client_id = "test-id"
+    config.spotify_client_secret = "test-secret"
+    config.slskd_host = "http://localhost:5030"
+    config.slskd_api_key = "test-key"
+    config.telegram_allowed_users = {12345}
+    config.auto_mode = False
+    config.max_results = 5
+    config.duration_tolerance_secs = 5
+    config.exclude_keywords = ["live", "remix"]
+    config.download_dir = os.path.join(td, "downloads")
+    config.output_dir = os.path.join(td, "music")
+    config.data_dir = os.path.join(td, "data")
+    config.filename_template = "{artist} - {title}"
+    config.search_timeout_secs = 30
+    config.download_timeout_secs = 600
+    config.download_cleanup_hours = 24
+    return config
+
+
+def _make_bot(config=None):
+    with (
+        patch("music_downloader.bot.handlers.SpotifyResolver"),
+        patch("music_downloader.bot.handlers.SlskdClient"),
+    ):
+        return MusicBot(config or _make_config())
+
+
+def _make_track():
+    return TrackInfo(
+        artist="Nancy Sinatra",
+        title="Bang Bang",
+        album="X",
+        duration_ms=162_000,
+        spotify_url="u",
+        year="1966",
+    )
+
+
+def _make_result(idx=0):
+    return SearchResult(
+        username=f"user{idx}",
+        filename=f"\\Music\\track{idx}.flac",
+        size=30_000_000,
+        bit_depth=16,
+        sample_rate=44100,
+        length=162,
+    )
+
+
+def _make_context():
+    context = MagicMock()
+    context.bot = AsyncMock()
+    context.application = MagicMock()
+    context.application.create_task = MagicMock(side_effect=lambda coro, **kw: asyncio.ensure_future(coro))
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Settings persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsPersistence:
+    def test_repo_roundtrip_and_default(self, tmp_path):
+        repo = SettingsRepository(Database(str(tmp_path / "db.sqlite")))
+        assert repo.get_auto_mode(1) is None
+        repo.set_auto_mode(1, True)
+        assert repo.get_auto_mode(1) is True
+        repo.set_auto_mode(1, False)
+        assert repo.get_auto_mode(1) is False
+
+    def test_toggle_survives_bot_restart(self, tmp_path):
+        config = _make_config(str(tmp_path))
+        bot1 = _make_bot(config)
+        bot1._set_auto(67890, True)
+
+        bot2 = _make_bot(config)  # same data_dir = same DB
+        assert bot2._is_auto(67890) is True
+
+    def test_config_default_applies_until_toggled(self, tmp_path):
+        config = _make_config(str(tmp_path))
+        config.auto_mode = True
+        bot = _make_bot(config)
+        assert bot._is_auto(111) is True  # env default
+        bot._set_auto(111, False)  # explicit toggle wins
+        assert bot._is_auto(111) is False
+
+
+# ---------------------------------------------------------------------------
+# Auto-download flow
+# ---------------------------------------------------------------------------
+
+
+class TestAutoDownloadFlow:
+    @pytest.mark.asyncio
+    async def test_auto_search_skips_picker_and_downloads_best(self):
+        bot = _make_bot()
+        bot._set_auto(67890, True)
+        results = [_make_result(0), _make_result(1)]
+        bot.slskd.search = AsyncMock(return_value=[{"files": []}])
+        bot.slskd.parse_results = MagicMock(return_value=results)
+        bot.scorer = MagicMock()
+        bot.scorer.score_results = MagicMock(return_value=results)
+
+        with patch.object(bot, "_launch_download", new_callable=AsyncMock) as mock_launch:
+            await bot._do_slskd_search(_make_context(), 67890, _make_track(), AsyncMock(), generation=0)
+
+        mock_launch.assert_awaited_once()
+        args = mock_launch.call_args[0]
+        assert args[3] == results[0]  # best match
+        assert args[4] == 0  # index
+
+    @pytest.mark.asyncio
+    async def test_manual_mode_still_shows_picker(self):
+        """Positive control: auto off keeps the keyboard flow."""
+        bot = _make_bot()
+        results = [_make_result(0)]
+        bot.slskd.search = AsyncMock(return_value=[{"files": []}])
+        bot.slskd.parse_results = MagicMock(return_value=results)
+        bot.scorer = MagicMock()
+        bot.scorer.score_results = MagicMock(return_value=results)
+
+        with (
+            patch.object(bot, "_launch_download", new_callable=AsyncMock) as mock_launch,
+            patch("music_downloader.bot.handlers._safe_edit", new_callable=AsyncMock) as mock_edit,
+        ):
+            await bot._do_slskd_search(_make_context(), 67890, _make_track(), AsyncMock(), generation=0)
+
+        mock_launch.assert_not_awaited()
+        assert mock_edit.call_args.kwargs.get("reply_markup") is not None
+
+    @pytest.mark.asyncio
+    async def test_auto_save_processes_without_approval(self, tmp_path):
+        bot = _make_bot()
+        source = tmp_path / "track.flac"
+        source.write_bytes(b"flac")
+        pending = PendingDownload(track=_make_track(), result=_make_result(), chat_id=67890, source_path=str(source))
+        bot.downloads["abc"] = pending
+        bot.processor = MagicMock()
+        bot.processor.process_file = MagicMock(return_value=str(tmp_path / "Nancy Sinatra - Bang Bang.flac"))
+        bot.processor.cleanup_download = MagicMock(return_value=True)
+        status_msg = AsyncMock()
+
+        with patch.object(bot, "_embed_spotify_artwork", new_callable=AsyncMock):
+            await bot._auto_save(67890, "abc", pending, status_msg, "quality", "#1")
+
+        assert "abc" not in bot.downloads
+        bot.processor.process_file.assert_called_once()
+        records = bot.history_repo.get_recent(5)
+        assert records and records[0].status == "success"
+        assert "Auto-saved" in status_msg.edit_text.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Unattended imports
+# ---------------------------------------------------------------------------
+
+
+class TestImportAutoSave:
+    def test_confirm_keyboard_offers_both_modes(self):
+        kb = build_import_confirm_keyboard(7)
+        callbacks = [b.callback_data for row in kb.inline_keyboard for b in row]
+        assert "ic:7" in callbacks
+        assert "ic:7:auto" in callbacks
+        assert "ix:7" in callbacks
+
+    @pytest.mark.asyncio
+    async def test_auto_import_saves_and_continues(self, tmp_path):
+        bot = _make_bot()
+        bot._import_auto[67890] = True
+        bot.import_repo = MagicMock()
+        bot.processor = MagicMock()
+        bot.processor.process_file = MagicMock(return_value=str(tmp_path / "out.flac"))
+        bot.processor.cleanup_download = MagicMock(return_value=True)
+
+        with (
+            patch.object(bot, "_embed_spotify_artwork", new_callable=AsyncMock),
+            patch.object(bot, "_process_next_import_track", new_callable=AsyncMock) as mock_next,
+            patch("music_downloader.bot.handlers.asyncio.to_thread", side_effect=lambda fn, *a, **k: fn(*a, **k)),
+        ):
+            await bot._import_auto_save(
+                _make_context(), 67890, 1, 2, "dl1", _make_track(), _make_result(), "/tmp/src.flac", AsyncMock(), 0
+            )
+
+        from music_downloader.persistence.import_repo import TrackStatus
+
+        bot.import_repo.complete_track.assert_called_once_with(1, 2, TrackStatus.completed)
+        mock_next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_import_failure_marks_failed_and_continues(self):
+        bot = _make_bot()
+        bot._import_auto[67890] = True
+        bot.import_repo = MagicMock()
+
+        with (
+            patch.object(bot, "_process_next_import_track", new_callable=AsyncMock) as mock_next,
+            patch("music_downloader.bot.handlers.asyncio.to_thread", side_effect=lambda fn, *a, **k: fn(*a, **k)),
+        ):
+            await bot._import_auto_fail(
+                _make_context(), 67890, 1, 2, "dl1", AsyncMock(), 0, "❌ failed — continuing.", "Timeout"
+            )
+
+        from music_downloader.persistence.import_repo import TrackStatus
+
+        bot.import_repo.complete_track.assert_called_once_with(1, 2, TrackStatus.failed, "Timeout")
+        mock_next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_status_shows_import_progress(self):
+        bot = _make_bot()
+        bot._active_import[67890] = 5
+        bot._import_auto[67890] = True
+        bot.import_repo = MagicMock()
+        bot.import_repo.get_job_progress = MagicMock(return_value=(3, 1, 0, 10))
+
+        update = MagicMock()
+        update.effective_user.id = 12345
+        update.effective_chat.id = 67890
+        update.message = AsyncMock()
+        update.effective_message = update.message
+
+        await bot.cmd_status(update, _make_context())
+
+        text = update.message.reply_text.call_args[0][0]
+        assert "Import (auto-save)" in text
+        assert "4/10" in text

--- a/tests/test_auto_mode.py
+++ b/tests/test_auto_mode.py
@@ -248,3 +248,149 @@ class TestImportAutoSave:
         text = update.message.reply_text.call_args[0][0]
         assert "Import (auto-save)" in text
         assert "4/10" in text
+
+
+class TestAutoBranchCoverage:
+    @pytest.mark.asyncio
+    async def test_auto_save_failure_records_process_failed(self, tmp_path):
+        bot = _make_bot()
+        source = tmp_path / "t.flac"
+        source.write_bytes(b"x")
+        pending = PendingDownload(track=_make_track(), result=_make_result(), chat_id=67890, source_path=str(source))
+        bot.downloads["zz"] = pending
+        bot.processor = MagicMock()
+        bot.processor.process_file = MagicMock(return_value=None)  # save fails
+        status_msg = AsyncMock()
+
+        await bot._auto_save(67890, "zz", pending, status_msg, "q", "#1")
+
+        records = bot.history_repo.get_recent(5)
+        assert records and records[0].status == "process_failed"
+        assert "failed to save" in status_msg.edit_text.call_args[0][0].lower()
+
+    @pytest.mark.asyncio
+    async def test_import_download_auto_enqueue_failure_routes_to_auto_fail(self):
+        bot = _make_bot()
+        bot._import_auto[67890] = True
+        bot.slskd.enqueue_download = MagicMock(return_value=False)
+
+        with patch.object(bot, "_import_auto_fail", new_callable=AsyncMock) as mock_fail:
+            await bot._do_import_download(
+                _make_context(),
+                67890,
+                _make_track(),
+                _make_result(),
+                AsyncMock(),
+                0,
+                job_id=1,
+                track_id=2,
+                dl_id="d1",
+            )
+        mock_fail.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_import_download_auto_timeout_routes_to_auto_fail(self):
+        bot = _make_bot()
+        bot._import_auto[67890] = True
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        bot.slskd.wait_for_download = AsyncMock(return_value=None)  # timeout
+
+        with patch.object(bot, "_import_auto_fail", new_callable=AsyncMock) as mock_fail:
+            await bot._do_import_download(
+                _make_context(),
+                67890,
+                _make_track(),
+                _make_result(),
+                AsyncMock(),
+                0,
+                job_id=1,
+                track_id=2,
+                dl_id="d1",
+            )
+        mock_fail.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_import_download_auto_success_routes_to_auto_save(self, tmp_path):
+        from music_downloader.search.slskd_client import DownloadStatus
+
+        bot = _make_bot()
+        bot._import_auto[67890] = True
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        bot.slskd.wait_for_download = AsyncMock(
+            return_value=DownloadStatus(username="u", filename="f", state="Completed, Succeeded")
+        )
+        source = tmp_path / "s.flac"
+        source.write_bytes(b"x")
+        bot.processor = MagicMock()
+        bot.processor.find_downloaded_file = MagicMock(return_value=str(source))
+        bot.downloads["d1"] = PendingDownload(track=_make_track(), result=_make_result(), chat_id=67890)
+
+        with patch.object(bot, "_import_auto_save", new_callable=AsyncMock) as mock_save:
+            await bot._do_import_download(
+                _make_context(),
+                67890,
+                _make_track(),
+                _make_result(),
+                AsyncMock(),
+                0,
+                job_id=1,
+                track_id=2,
+                dl_id="d1",
+            )
+        mock_save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_import_auto_save_failure_marks_failed_and_continues(self):
+        bot = _make_bot()
+        bot.import_repo = MagicMock()
+        bot.processor = MagicMock()
+        bot.processor.process_file = MagicMock(return_value=None)
+
+        with (
+            patch.object(bot, "_process_next_import_track", new_callable=AsyncMock) as mock_next,
+            patch("music_downloader.bot.handlers.asyncio.to_thread", side_effect=lambda fn, *a, **k: fn(*a, **k)),
+        ):
+            await bot._import_auto_save(
+                _make_context(), 67890, 1, 2, "d1", _make_track(), _make_result(), "/tmp/s.flac", AsyncMock(), 0
+            )
+
+        from music_downloader.persistence.import_repo import TrackStatus
+
+        assert bot.import_repo.complete_track.call_args[0][2] == TrackStatus.failed
+        mock_next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ic_auto_callback_sets_unattended_mode(self):
+        bot = _make_bot()
+        bot.import_repo = MagicMock()
+        bot.import_repo.get_job_for_chat = MagicMock(return_value=MagicMock(id=1))
+
+        update = MagicMock()
+        update.callback_query = AsyncMock()
+        context = _make_context()
+        context.application.create_task = MagicMock(return_value=MagicMock())
+
+        with patch("music_downloader.bot.handlers.asyncio.to_thread", side_effect=lambda fn, *a, **k: fn(*a, **k)):
+            await bot._handle_import_callback(update, context, 67890, "ic:1:auto")
+
+        assert bot._import_auto.get(67890) is True
+
+    @pytest.mark.asyncio
+    async def test_do_download_auto_routes_to_auto_save(self, tmp_path):
+        from music_downloader.search.slskd_client import DownloadStatus
+
+        bot = _make_bot()
+        bot._set_auto(67890, True)
+        bot.slskd.enqueue_download = MagicMock(return_value=True)
+        bot.slskd.wait_for_download = AsyncMock(
+            return_value=DownloadStatus(username="u", filename="f", state="Completed, Succeeded")
+        )
+        source = tmp_path / "s.flac"
+        source.write_bytes(b"x")
+        bot.processor = MagicMock()
+        bot.processor.find_downloaded_file = MagicMock(return_value=str(source))
+        bot.processor.build_filename = MagicMock(return_value="n.flac")
+
+        with patch.object(bot, "_auto_save", new_callable=AsyncMock) as mock_auto:
+            await bot._do_download(_make_context(), 67890, _make_track(), _make_result(), AsyncMock(), 0, "sid")
+        mock_auto.assert_awaited_once()

--- a/tests/test_handlers_comprehensive.py
+++ b/tests/test_handlers_comprehensive.py
@@ -248,7 +248,7 @@ class TestMusicBotInit:
     def test_init(self, mock_slskd, mock_spotify):
         config = _make_config()
         bot = MusicBot(config)
-        assert bot.auto_mode is False
+        assert bot._is_auto(67890) is False  # config default, no stored setting
         assert bot.pending == {}
         assert bot.downloads == {}
         assert bot.history_repo is not None
@@ -495,7 +495,8 @@ class TestMusicBotCallbackHandler:
         update = _make_callback_update(data="auto:on")
         context = _make_context()
         await bot.handle_callback(update, context)
-        assert bot.auto_mode is True
+        assert bot._is_auto(67890) is True
+        assert bot.settings_repo.get_auto_mode(67890) is True  # survives restarts
 
     @patch("music_downloader.bot.handlers.SpotifyResolver")
     @patch("music_downloader.bot.handlers.SlskdClient")
@@ -507,7 +508,7 @@ class TestMusicBotCallbackHandler:
         update = _make_callback_update(data="auto:off")
         context = _make_context()
         await bot.handle_callback(update, context)
-        assert bot.auto_mode is False
+        assert bot._is_auto(67890) is False
 
     @patch("music_downloader.bot.handlers.SpotifyResolver")
     @patch("music_downloader.bot.handlers.SlskdClient")
@@ -783,7 +784,7 @@ class TestMusicBotCallbackHandler:
         context = _make_context()
         await bot.handle_callback(update, context)
         # Should not change auto_mode
-        assert bot.auto_mode is False
+        assert bot._is_auto(67890) is False
 
 
 class TestMusicBotHelpers:

--- a/uv.lock
+++ b/uv.lock
@@ -820,7 +820,7 @@ wheels = [
 
 [[package]]
 name = "telegram-slskd-local-bot"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
AUTO_MODE has been documented, logged, and toggleable since 0.1.0 — and never did anything. The flag was stored and displayed but no code path ever read it (tsb-71d). This makes the promise real, and extends it to imports (tsb-78b):

- **`/auto` now works, per chat, persisted.** When on, a search skips the picker (best-ranked match downloads immediately, the result list is still shown for transparency) and skips the approval step: the file is saved to the library, tagged with artwork, recorded in history, and confirmed in one message. The setting lives in a new `chat_settings` table so it survives restarts; `AUTO_MODE` (env) is only the default for chats that never toggled.
- **Imports can run unattended.** The confirm screen now offers "Review each track" vs "Auto-save all". Auto-save imports run start to finish with zero taps and zero Telegram preview uploads (a 40-track album used to mean 40 taps and ~1.5GB pushed through Telegram just for previews); failed tracks are marked failed and the import continues instead of pausing on a keyboard.
- **`/status` shows import progress**: mode, processed/total, saved/failed/skipped — imports were previously invisible to it.
- Docs un-reserve AUTO_MODE (README, .env.example, command menu) and the README's inline compose example now mounts `/downloads` read-write like the shipped compose.

Version bumped to 0.12.0 (with #37's orphan sweeper). 12 new tests; 463 total, all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic downloading of the best-ranked search result when Auto Mode is enabled.
  - Added per-chat Auto Mode settings that persist between sessions.
  - Added playlist and album imports with options to review tracks or save them automatically.
  - Added import progress reporting through `/status`.
  - Added automatic cleanup of rejected and abandoned downloads.

- **Documentation**
  - Updated setup instructions, command descriptions, and the changelog for version 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->